### PR TITLE
Bufix/merge with different schemas on bq

### DIFF
--- a/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
+++ b/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
@@ -34,7 +34,9 @@ import scala.collection.JavaConverters._
   *   : Cusom spark application name prefix. The current datetime is appended this the Spark Job
   *   name
   */
-class SparkEnv(name: String)(implicit settings: Settings) extends StrictLogging {
+class SparkEnv(name: String, extraSparkConf: Map[String, String] = Map.empty)(implicit
+  settings: Settings
+) extends StrictLogging {
 
   /** Load spark.* properties from the loaded application conf file
     */
@@ -53,10 +55,12 @@ class SparkEnv(name: String)(implicit settings: Settings) extends StrictLogging 
       .setAppName(appName)
       .set("spark.app.id", appName)
 
+    val withExtraConf = extraSparkConf.foldLeft(thisConf) { case (conf, (k, v)) => conf.set(k, v) }
+
     logger.whenDebugEnabled {
-      thisConf.getAll.foreach { case (k, v) => logger.debug(s"$k=$v") }
+      withExtraConf.getAll.foreach { case (k, v) => logger.debug(s"$k=$v") }
     }
-    thisConf
+    withExtraConf
   }
 
   /** Creates a Spark Session with the spark.* keys defined the application conf file.

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
@@ -31,6 +31,15 @@ class BigQuerySparkJob(
     extends SparkJob
     with BigQueryJobBase {
 
+  override def withExtraSparkConf(): Map[String, String] =
+    if (cliConfig.writeDisposition == "WRITE_TRUNCATE")
+      cliConfig.options ++ Map(
+        "spark.datasource.bigquery.allowFieldAddition"   -> "false",
+        "spark.datasource.bigquery.allowFieldRelaxation" -> "false"
+      )
+    else
+      cliConfig.options
+
   override def name: String = s"bqload-${cliConfig.outputDataset}-${cliConfig.outputTable}"
 
   val conf: Configuration = session.sparkContext.hadoopConfiguration

--- a/src/main/scala/com/ebiznext/comet/job/index/connectionload/ConnectionLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/connectionload/ConnectionLoadJob.scala
@@ -12,6 +12,11 @@ class ConnectionLoadJob(
 )(implicit val settings: Settings)
     extends SparkJob {
 
+  /** Set extra spark conf here otherwise it will be too late once the spark session is created.
+    * @return
+    */
+  override def withExtraSparkConf(): Map[String, String] = cliConfig.options
+
   override def name: String = s"jdbcload-JDBC-${cliConfig.outputTable}"
 
   val conf = session.sparkContext.hadoopConfiguration

--- a/src/main/scala/com/ebiznext/comet/job/index/esload/ESLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/esload/ESLoadJob.scala
@@ -39,6 +39,11 @@ class ESLoadJob(
 )(implicit val settings: Settings)
     extends SparkJob {
 
+  /** Set extra spark conf here otherwise it will be too late once the spark session is created.
+    * @return
+    */
+  override def withExtraSparkConf(): Map[String, String] = cliConfig.options
+
   val esresource = Some(("es.resource.write", s"${cliConfig.getResource()}"))
   val esId = cliConfig.id.map("es.mapping.id" -> _)
   val esCliConf = cliConfig.options ++ List(esresource, esId).flatten.toMap

--- a/src/main/scala/com/ebiznext/comet/utils/Job.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/Job.scala
@@ -64,8 +64,10 @@ trait JobBase extends StrictLogging {
 
 trait SparkJob extends JobBase {
 
+  def withExtraSparkConf(): Map[String, String] = Map.empty
+
   lazy val sparkEnv: SparkEnv = {
-    new SparkEnv(name)
+    new SparkEnv(name, withExtraSparkConf())
   }
 
   protected def registerUdf(udf: String): Unit = {


### PR DESCRIPTION
## Summary
Support Merge On BigQuery
When WRITE_TRUNCATE is select, Spark fo BQ refuse to have allowFieldAddition/allowFieldDeletion active.

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**

