### PR TITLE
Feature/schema on write

### DIFF
--- a/src/main/scala/com/ebiznext/comet/extractor/ExtractScriptGenConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/extractor/ExtractScriptGenConfig.scala
@@ -23,8 +23,8 @@ object ExtractScriptGenConfig extends CliConfig[ExtractScriptGenConfig] {
     val builder = OParser.builder[ExtractScriptGenConfig]
     import builder._
     OParser.sequence(
-      programName("comet extract"),
-      head("comet", "extract", "[options]"),
+      programName("starlake extract"),
+      head("starlake", "extract", "[options]"),
       note(
         """
           |For domain extraction, the schemas should at least, specify :

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -35,6 +35,7 @@ import com.ebiznext.comet.job.metrics.MetricsConfig
 import com.ebiznext.comet.schema.generator.{
   Xls2Yml,
   Xls2YmlConfig,
+  Yml2DDLConfig,
   Yml2GraphViz,
   Yml2GraphVizConfig,
   Yml2XlsConfig,
@@ -210,10 +211,18 @@ object Main extends StrictLogging {
             false
         }
 
+      case "infer-ddl" =>
+        Yml2DDLConfig.parse(args.drop(1)) match {
+          case Some(config) =>
+            workflow.inferDDL(config).isSuccess
+          case _ =>
+            println(Yml2DDLConfig.usage())
+            false
+        }
       case "infer-schema" =>
         InferSchemaConfig.parse(args.drop(1)) match {
           case Some(config) =>
-            workflow.infer(config).isSuccess
+            workflow.inferSchema(config).isSuccess
           case _ =>
             println(InferSchemaConfig.usage())
             false

--- a/src/main/scala/com/ebiznext/comet/job/atlas/AtlasConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/atlas/AtlasConfig.scala
@@ -18,8 +18,8 @@ object AtlasConfig extends CliConfig[AtlasConfig] {
     val builder = OParser.builder[AtlasConfig]
     import builder._
     OParser.sequence(
-      programName("comet atlas"),
-      head("comet", "atlas", "[options]"),
+      programName("starlake atlas"),
+      head("starlake", "atlas", "[options]"),
       note(""),
       opt[Unit]("delete")
         .action((_, c) => c.copy(delete = true))

--- a/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSVConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSVConfig.scala
@@ -22,8 +22,8 @@ object Parquet2CSVConfig extends CliConfig[Parquet2CSVConfig] {
     val builder = OParser.builder[Parquet2CSVConfig]
     import builder._
     OParser.sequence(
-      programName("comet parquet2csv"),
-      head("comet", "parquet2csv", "[options]"),
+      programName("starlake parquet2csv"),
+      head("starlake", "parquet2csv", "[options]"),
       note(
         """
           |Convert parquet files to CSV.

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadConfig.scala
@@ -31,8 +31,8 @@ object BigQueryLoadConfig extends CliConfig[BigQueryLoadConfig] {
     val builder = OParser.builder[BigQueryLoadConfig]
     import builder._
     OParser.sequence(
-      programName("comet bqload"),
-      head("comet", "bqload", "[options]"),
+      programName("starlake bqload"),
+      head("starlake", "bqload", "[options]"),
       note(""),
       opt[String]("source_file")
         .action((x, c) => c.copy(source = Left(x)))

--- a/src/main/scala/com/ebiznext/comet/job/index/connectionload/ConnectionLoadConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/connectionload/ConnectionLoadConfig.scala
@@ -91,8 +91,8 @@ object ConnectionLoadConfig extends CliConfig[ConnectionLoadConfig] {
     val builder = OParser.builder[ConnectionLoadConfig]
     import builder._
     OParser.sequence(
-      programName("comet cnxload"),
-      head("comet", "cnxload", "[options]"),
+      programName("starlake cnxload"),
+      head("starlake", "cnxload", "[options]"),
       note("""
           |Load parquet file into JDBC Table.
           |""".stripMargin),

--- a/src/main/scala/com/ebiznext/comet/job/index/esload/ESLoadConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/esload/ESLoadConfig.scala
@@ -82,8 +82,8 @@ object ESLoadConfig extends CliConfig[ESLoadConfig] {
     val builder = OParser.builder[ESLoadConfig]
     import builder._
     OParser.sequence(
-      programName("comet esload | index"),
-      head("comet", "index | esload", "[options]"),
+      programName("starlake esload | index"),
+      head("starlake", "index | esload", "[options]"),
       note(""),
       opt[String]("timestamp")
         .action((x, c) => c.copy(timestamp = Some(x)))

--- a/src/main/scala/com/ebiznext/comet/job/index/esload/ESLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/esload/ESLoadJob.scala
@@ -87,7 +87,7 @@ class ESLoadJob(
       val dynamicTemplate = for {
         domain <- schemaHandler.getDomain(cliConfig.domain)
         schema <- domain.schemas.find(_.name == cliConfig.schema)
-      } yield schema.mapping(domain.mapping(schema), domain.name, schemaHandler)
+      } yield schema.esMapping(domain.esMapping(schema), domain.name, schemaHandler)
 
       dynamicTemplate.getOrElse {
         // Handle datasets without YAML schema

--- a/src/main/scala/com/ebiznext/comet/job/index/kafkaload/KafkaJobConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/kafkaload/KafkaJobConfig.scala
@@ -38,8 +38,8 @@ object KafkaJobConfig extends CliConfig[KafkaJobConfig] {
     val builder = OParser.builder[KafkaJobConfig]
     import builder._
     OParser.sequence(
-      programName("comet kafkaload"),
-      head("comet", "kafkaload", "[options]"),
+      programName("starlake kafkaload"),
+      head("starlake", "kafkaload", "[options]"),
       note("""
           |Two modes are available : The batch mode and the streaming mode.
           |

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
@@ -36,8 +36,8 @@ object InferSchemaConfig extends CliConfig[InferSchemaConfig] {
     val builder = OParser.builder[InferSchemaConfig]
     import builder._
     OParser.sequence(
-      programName("comet infer-schema"),
-      head("comet", "infer-schema", "[options]"),
+      programName("starlake infer-schema"),
+      head("starlake", "infer-schema", "[options]"),
       note(""),
       opt[String]("domain")
         .action((x, c) => c.copy(domainName = x))

--- a/src/main/scala/com/ebiznext/comet/job/ingest/LoadConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/LoadConfig.scala
@@ -44,8 +44,8 @@ object LoadConfig extends CliConfig[LoadConfig] {
     val builder = OParser.builder[LoadConfig]
     import builder._
     OParser.sequence(
-      programName("comet load | ingest"),
-      head("comet", "load | ingest", "[options]"),
+      programName("starlake load | ingest"),
+      head("starlake", "load | ingest", "[options]"),
       note(""),
       arg[String]("domain")
         .required()

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsConfig.scala
@@ -12,8 +12,8 @@ object MetricsConfig extends CliConfig[MetricsConfig] {
     val builder = OParser.builder[MetricsConfig]
     import builder._
     OParser.sequence(
-      programName("comet metrics"),
-      head("comet", "metrics", "[options]"),
+      programName("starlake metrics"),
+      head("starlake", "metrics", "[options]"),
       note(""),
       opt[String]("domain")
         .action((x, c) => c.copy(domain = x))

--- a/src/main/scala/com/ebiznext/comet/schema/generator/DDL2Yml.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/DDL2Yml.scala
@@ -1,54 +1,14 @@
 package com.ebiznext.comet.schema.generator
 
 import better.files.File
-import com.ebiznext.comet.config.{DatasetArea, Settings}
-import com.ebiznext.comet.schema.model.{Attribute, Domain, Schema}
+import com.ebiznext.comet.config.Settings
+import com.ebiznext.comet.schema.model.Domain
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 
-import java.sql.DriverManager
-import java.sql.Types._
-import java.util.Properties
-import java.util.regex.Pattern
-import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 import scala.util.{Failure, Success}
 
 object DDL2Yml extends LazyLogging {
-
-  // java.sql.Types
-  val sqlTypes = Map(
-    "BIT"                     -> -7,
-    "TINYINT"                 -> -6,
-    "SMALLINT"                -> 5,
-    "INTEGER"                 -> 4,
-    "BIGINT"                  -> -5,
-    "FLOAT"                   -> 6,
-    "REAL"                    -> 7,
-    "DOUBLE"                  -> 8,
-    "NUMERIC"                 -> 2,
-    "DECIMAL"                 -> 3,
-    "CHAR"                    -> 1,
-    "VARCHAR"                 -> 12,
-    "LONGVARCHAR"             -> -1,
-    "DATE"                    -> 91,
-    "TIME"                    -> 92,
-    "TIMESTAMP"               -> 93,
-    "BINARY"                  -> -2,
-    "VARBINARY"               -> -3,
-    "LONGVARBINARY"           -> -4,
-    "NULL"                    -> 0,
-    "OTHER"                   -> 1111,
-    "BOOLEAN"                 -> 16,
-    "NVARCHAR"                -> -9,
-    "NCHAR"                   -> -15,
-    "LONGNVARCHAR"            -> -16,
-    "TIME_WITH_TIMEZONE"      -> 2013,
-    "TIMESTAMP_WITH_TIMEZONE" -> 2014
-  )
-
-  // The other part of the biMap
-  val reverseSqlTypes = sqlTypes map (_.swap)
 
   def run(args: Array[String]): Unit = {
     implicit val settings: Settings = Settings(ConfigFactory.load())
@@ -84,215 +44,28 @@ object DDL2Yml extends LazyLogging {
     }
   }
 
+  def run(jdbcSchema: JDBCSchema, outputDir: File, domainTemplate: Option[Domain])(implicit
+    settings: Settings
+  ): Unit = {
+    val domain = run(jdbcSchema, domainTemplate)
+    YamlSerializer.serializeToFile(
+      File(outputDir, jdbcSchema.schema + ".comet.yml"),
+      domain
+    )
+  }
+
   /** Generate YML file from the JDBCSchema
     *
     * @param jdbcSchema
     *   : the JDBC Schema to extract
-    * @param ymlOutputDir
-    *   : Where to output the YML file. The generated filename will be in the for
-    *   TABLE_SCHEMA_NAME.yml
     * @param settings
     *   : Application configuration file
     */
-  def run(jdbcSchema: JDBCSchema, ymlOutputDir: File, domainTemplate: Option[Domain])(implicit
+  def run(jdbcSchema: JDBCSchema, domainTemplate: Option[Domain])(implicit
     settings: Settings
-  ): Unit = {
-    val jdbcOptions = settings.comet.connections(jdbcSchema.connection)
-    // Only JDBC connections are supported
-    assert(jdbcOptions.format == "jdbc")
-    val url = jdbcOptions.options("url")
-    val properties = new Properties()
-    (jdbcOptions.options - "url").foreach { case (key, value) =>
-      properties.setProperty(key, value)
-    }
-    val connection = DriverManager.getConnection(url, properties)
-    val databaseMetaData = connection.getMetaData()
-    val jdbcTableMap =
-      jdbcSchema.tables
-        .map(tblSchema => tblSchema.name.toUpperCase -> tblSchema)
-        .toMap
-    val tableNames = jdbcTableMap.keys.toList
-
-    /* Extract all tables from the database and return Map of tablename -> tableDescription */
-    def extractTables(): Map[String, String] = {
-      val tableNames = mutable.Map.empty[String, String]
-      val resultSet = databaseMetaData.getTables(
-        jdbcSchema.catalog.orNull,
-        jdbcSchema.schema,
-        "%",
-        jdbcSchema.tableTypes.toArray
-      )
-      while (resultSet.next()) {
-        val tableName = resultSet.getString("TABLE_NAME");
-        val remarks = resultSet.getString("REMARKS");
-        tableNames += tableName -> remarks
-      }
-      resultSet.close()
-      tableNames.toMap
-    }
-
-    val allExtractedTables = extractTables()
-    logger.whenDebugEnabled {
-      extractTables.keys.foreach(table => logger.debug(s"Found: $table"))
-    } // If the user specified a list of table to extract we limit the table sot extract to those ones
-    val selectedTables = tableNames match {
-      case Nil =>
-        allExtractedTables
-      case list =>
-        allExtractedTables.filter { case (table, _) =>
-          list.contains(table.toUpperCase) || list.contains("*")
-        }
-    }
-    logger.whenInfoEnabled {
-      selectedTables.keys.foreach(table => logger.info(s"Selected: $table"))
-    }
-
-    val schemaMetadata =
-      domainTemplate.flatMap(_.schemas.headOption.flatMap(_.metadata))
-    // Extract the Comet Schema
-    val cometSchema = selectedTables.map { case (tableName, tableRemarks) =>
-      // Find all foreign keys
-      val foreignKeysResultSet = databaseMetaData.getImportedKeys(
-        jdbcSchema.catalog.orNull,
-        jdbcSchema.schema,
-        tableName
-      )
-      val foreignKeys = new Iterator[(String, String)] {
-        def hasNext: Boolean = foreignKeysResultSet.next()
-        def next(): (String, String) = {
-          val pkSchemaName = foreignKeysResultSet.getString("PKTABLE_SCHEM")
-          val pkTableName = foreignKeysResultSet.getString("PKTABLE_NAME")
-          val pkColumnName = foreignKeysResultSet.getString("PKCOLUMN_NAME")
-          val fkColumnName = foreignKeysResultSet.getString("FKCOLUMN_NAME").toUpperCase
-
-          val pkCompositeName =
-            if (pkSchemaName == null) s"$pkTableName.$pkColumnName"
-            else s"$pkSchemaName.$pkTableName.$pkColumnName"
-
-          fkColumnName -> pkCompositeName
-        }
-      }.toMap
-
-      // Extract all columns
-      val columnsResultSet = databaseMetaData.getColumns(
-        jdbcSchema.catalog.orNull,
-        jdbcSchema.schema,
-        tableName,
-        null
-      )
-      val attrs = new Iterator[Attribute] {
-        def hasNext: Boolean = columnsResultSet.next()
-        def next(): Attribute = {
-          val colName = columnsResultSet.getString("COLUMN_NAME")
-          logger.info(s"COLUMN_NAME=$tableName.$colName")
-          val colType = columnsResultSet.getInt("DATA_TYPE")
-          val colRemarks = columnsResultSet.getString("REMARKS")
-          val colRequired = columnsResultSet.getString("IS_NULLABLE").equals("NO")
-          val foreignKey = foreignKeys.get(colName.toUpperCase)
-
-          Attribute(
-            name = colName,
-            `type` = sparkType(colType, tableName, colName),
-            required = colRequired,
-            comment = Option(colRemarks),
-            foreignKey = foreignKey
-          )
-        }
-      }.to[ListBuffer]
-      // remove duplicates
-      // see https://stackoverflow.com/questions/1601203/jdbc-databasemetadata-getcolumns-returns-duplicate-columns
-      val columns = attrs.groupBy(_.name).map { case (_, uniqAttr) => uniqAttr.head }
-
-      logger.whenDebugEnabled {
-        columns.foreach(column => logger.debug(s"column: $tableName.${column.name}"))
-      }
-
-      // Limit to the columns specified by the user if any
-      val currentTableRequestedColumns =
-        jdbcTableMap
-          .get(tableName)
-          .map(_.columns.getOrElse(Nil).map(_.toUpperCase))
-          .getOrElse(Nil)
-      val selectedColumns =
-        if (currentTableRequestedColumns.isEmpty)
-          columns.toList
-        else
-          columns.toList.filter(col =>
-            currentTableRequestedColumns.contains(col.name.toUpperCase())
-          )
-      logger.whenDebugEnabled {
-        columns.foreach(column => logger.debug(s"Final schema column: $tableName.${column.name}"))
-      }
-
-      //      // Find primary keys
-      val primaryKeysResultSet = databaseMetaData.getPrimaryKeys(
-        jdbcSchema.catalog.orNull,
-        jdbcSchema.schema,
-        tableName
-      )
-      val primaryKeys = new Iterator[String] {
-        def hasNext: Boolean = primaryKeysResultSet.next()
-        def next(): String = primaryKeysResultSet.getString("COLUMN_NAME")
-      }.toList
-
-      Schema(
-        name = tableName,
-        pattern = Pattern.compile(s"$tableName.*"),
-        attributes = selectedColumns,
-        metadata = schemaMetadata,
-        merge = None,
-        comment = Option(tableRemarks),
-        presql = None,
-        postsql = None,
-        primaryKey = if (primaryKeys.isEmpty) None else Some(primaryKeys)
-      )
-    }
-    // Generate the domain with a dummy watch directory
-    val incomingDir = domainTemplate
-      .map { dom =>
-        DatasetArea
-          .substituteDomainAndSchemaInPath(jdbcSchema.schema, "", dom.directory)
-          .toString
-      }
-      .getOrElse(s"/${jdbcSchema.schema}")
-
-    val domain =
-      Domain(
-        jdbcSchema.schema,
-        incomingDir,
-        domainTemplate.flatMap(_.metadata),
-        None,
-        cometSchema.toList,
-        None,
-        domainTemplate.flatMap(_.extensions),
-        domainTemplate.flatMap(_.ack)
-      )
-    YamlSerializer.serializeToFile(File(ymlOutputDir, jdbcSchema.schema + ".comet.yml"), domain)
-    connection.close()
-  }
-
-  private def sparkType(jdbcType: Int, tableName: String, colName: String): String = {
-    val sqlType = reverseSqlTypes.getOrElse(jdbcType, s"UNKNOWN JDBC TYPE => $jdbcType")
-    jdbcType match {
-      case VARCHAR | CHAR | LONGVARCHAR          => "string"
-      case BIT | BOOLEAN                         => "boolean"
-      case DOUBLE | FLOAT | REAL                 => "double"
-      case NUMERIC | DECIMAL                     => "decimal"
-      case TINYINT | SMALLINT | INTEGER | BIGINT => "long"
-      case DATE                                  => "date"
-      case TIMESTAMP                             => "timestamp"
-      case TIMESTAMP_WITH_TIMEZONE =>
-        logger.warn(s"forced conversion for $tableName.$colName from $sqlType to timestamp")
-        "timestamp"
-      case VARBINARY | BINARY =>
-        logger.warn(s"forced conversion for $tableName.$colName from $sqlType to string")
-        "string"
-      case _ =>
-        logger.error(
-          s"""unsupported column type for $tableName.$colName  -> $sqlType ($jdbcType)"""
-        )
-        sqlType
-    }
+  ): Domain = {
+    val selectedTablesAndColumns = DDLUtils.extractJDBCTables(jdbcSchema)
+    DDLUtils.extractDomain(jdbcSchema, domainTemplate, selectedTablesAndColumns)
   }
 
   def main(args: Array[String]): Unit = {

--- a/src/main/scala/com/ebiznext/comet/schema/generator/DDL2YmlConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/DDL2YmlConfig.scala
@@ -74,8 +74,8 @@ object DDL2YmlConfig extends CliConfig[DDL2YmlConfig] {
     val builder = OParser.builder[DDL2YmlConfig]
     import builder._
     OParser.sequence(
-      programName("comet ddl2yml"),
-      head("comet", "ddl2yml", "[options]"),
+      programName("starlake ddl2yml"),
+      head("starlake", "ddl2yml", "[options]"),
       note(""),
       opt[String]("jdbc-mapping")
         .action((x, c) => c.copy(jdbcMapping = x))

--- a/src/main/scala/com/ebiznext/comet/schema/generator/DDLUtils.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/DDLUtils.scala
@@ -1,0 +1,271 @@
+package com.ebiznext.comet.schema.generator
+
+import com.ebiznext.comet.config.{DatasetArea, Settings}
+import com.ebiznext.comet.schema.model.{Attribute, Domain, Schema}
+import com.typesafe.scalalogging.LazyLogging
+
+import java.sql.DriverManager
+import java.sql.Types._
+import java.util.Properties
+import java.util.regex.Pattern
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+object DDLUtils extends LazyLogging {
+
+  type TableRemarks = String
+  type Columns = List[Attribute]
+  type PrimaryKeys = List[String]
+
+  // java.sql.Types
+  val sqlTypes = Map(
+    "BIT"                     -> -7,
+    "TINYINT"                 -> -6,
+    "SMALLINT"                -> 5,
+    "INTEGER"                 -> 4,
+    "BIGINT"                  -> -5,
+    "FLOAT"                   -> 6,
+    "REAL"                    -> 7,
+    "DOUBLE"                  -> 8,
+    "NUMERIC"                 -> 2,
+    "DECIMAL"                 -> 3,
+    "CHAR"                    -> 1,
+    "VARCHAR"                 -> 12,
+    "LONGVARCHAR"             -> -1,
+    "DATE"                    -> 91,
+    "TIME"                    -> 92,
+    "TIMESTAMP"               -> 93,
+    "BINARY"                  -> -2,
+    "VARBINARY"               -> -3,
+    "LONGVARBINARY"           -> -4,
+    "NULL"                    -> 0,
+    "OTHER"                   -> 1111,
+    "BOOLEAN"                 -> 16,
+    "NVARCHAR"                -> -9,
+    "NCHAR"                   -> -15,
+    "LONGNVARCHAR"            -> -16,
+    "TIME_WITH_TIMEZONE"      -> 2013,
+    "TIMESTAMP_WITH_TIMEZONE" -> 2014
+  )
+
+  // The other part of the biMap
+  val reverseSqlTypes = sqlTypes map (_.swap)
+
+  def extractJDBCTables(
+    jdbcSchema: JDBCSchema
+  )(implicit settings: Settings): Map[String, (TableRemarks, Columns, PrimaryKeys)] = {
+    val jdbcOptions = settings.comet.connections(jdbcSchema.connection)
+    // Only JDBC connections are supported
+    assert(jdbcOptions.format == "jdbc")
+    val url = jdbcOptions.options("url")
+    val properties = new Properties()
+    (jdbcOptions.options - "url").foreach { case (key, value) =>
+      properties.setProperty(key, value)
+    }
+    val connection = DriverManager.getConnection(url, properties)
+    val databaseMetaData = connection.getMetaData()
+    val jdbcTableMap =
+      jdbcSchema.tables
+        .map(tblSchema => tblSchema.name.toUpperCase -> tblSchema)
+        .toMap
+    val tableNames = jdbcTableMap.keys.toList
+
+    /* Extract all tables from the database and return Map of tablename -> tableDescription */
+    def extractTables(): Map[String, String] = {
+      val tableNames = mutable.Map.empty[String, String]
+      val resultSet = databaseMetaData.getTables(
+        jdbcSchema.catalog.orNull,
+        jdbcSchema.schema,
+        "%",
+        jdbcSchema.tableTypes.toArray
+      )
+      while (resultSet.next()) {
+        val tableName = resultSet.getString("TABLE_NAME");
+        val remarks = resultSet.getString("REMARKS");
+        tableNames += tableName -> remarks
+      }
+      resultSet.close()
+      tableNames.toMap
+    }
+
+    val allExtractedTables = extractTables()
+    logger.whenDebugEnabled {
+      extractTables.keys.foreach(table => logger.debug(s"Found: $table"))
+    } // If the user specified a list of table to extract we limit the table sot extract to those ones
+    val selectedTables = tableNames match {
+      case Nil =>
+        allExtractedTables
+      case list =>
+        allExtractedTables.filter { case (table, _) =>
+          list.contains(table.toUpperCase) || list.contains("*")
+        }
+    }
+    logger.whenInfoEnabled {
+      selectedTables.keys.foreach(table => logger.info(s"Selected: $table"))
+    }
+
+    // Extract the Comet Schema
+    val selectedTablesAndColumns: Map[String, (TableRemarks, Columns, PrimaryKeys)] =
+      selectedTables.map { case (tableName, tableRemarks) =>
+        // Find all foreign keys
+        val foreignKeysResultSet = databaseMetaData.getImportedKeys(
+          jdbcSchema.catalog.orNull,
+          jdbcSchema.schema,
+          tableName
+        )
+        val foreignKeys = new Iterator[(String, String)] {
+          def hasNext: Boolean = foreignKeysResultSet.next()
+
+          def next(): (String, String) = {
+            val pkSchemaName = foreignKeysResultSet.getString("PKTABLE_SCHEM")
+            val pkTableName = foreignKeysResultSet.getString("PKTABLE_NAME")
+            val pkColumnName = foreignKeysResultSet.getString("PKCOLUMN_NAME")
+            val fkColumnName = foreignKeysResultSet.getString("FKCOLUMN_NAME").toUpperCase
+
+            val pkCompositeName =
+              if (pkSchemaName == null) s"$pkTableName.$pkColumnName"
+              else s"$pkSchemaName.$pkTableName.$pkColumnName"
+
+            fkColumnName -> pkCompositeName
+          }
+        }.toMap
+
+        // Extract all columns
+        val columnsResultSet = databaseMetaData.getColumns(
+          jdbcSchema.catalog.orNull,
+          jdbcSchema.schema,
+          tableName,
+          null
+        )
+        val attrs = new Iterator[Attribute] {
+          def hasNext: Boolean = columnsResultSet.next()
+
+          def next(): Attribute = {
+            val colName = columnsResultSet.getString("COLUMN_NAME")
+            logger.info(s"COLUMN_NAME=$tableName.$colName")
+            val colType = columnsResultSet.getInt("DATA_TYPE")
+            val colRemarks = columnsResultSet.getString("REMARKS")
+            val colRequired = columnsResultSet.getString("IS_NULLABLE").equals("NO")
+            val foreignKey = foreignKeys.get(colName.toUpperCase)
+
+            Attribute(
+              name = colName,
+              `type` = sparkType(colType, tableName, colName),
+              required = colRequired,
+              comment = Option(colRemarks),
+              foreignKey = foreignKey
+            )
+          }
+        }.to[ListBuffer]
+        // remove duplicates
+        // see https://stackoverflow.com/questions/1601203/jdbc-databasemetadata-getcolumns-returns-duplicate-columns
+        val columns = attrs.groupBy(_.name).map { case (_, uniqAttr) => uniqAttr.head }
+
+        logger.whenDebugEnabled {
+          columns.foreach(column => logger.debug(s"column: $tableName.${column.name}"))
+        }
+
+        // Limit to the columns specified by the user if any
+        val currentTableRequestedColumns =
+          jdbcTableMap
+            .get(tableName)
+            .map(_.columns.getOrElse(Nil).map(_.toUpperCase))
+            .getOrElse(Nil)
+        val selectedColumns =
+          if (currentTableRequestedColumns.isEmpty)
+            columns.toList
+          else
+            columns.toList.filter(col =>
+              currentTableRequestedColumns.contains(col.name.toUpperCase())
+            )
+        logger.whenDebugEnabled {
+          columns.foreach(column => logger.debug(s"Final schema column: $tableName.${column.name}"))
+        }
+
+        //      // Find primary keys
+        val primaryKeysResultSet = databaseMetaData.getPrimaryKeys(
+          jdbcSchema.catalog.orNull,
+          jdbcSchema.schema,
+          tableName
+        )
+        val primaryKeys = new Iterator[String] {
+          def hasNext: Boolean = primaryKeysResultSet.next()
+
+          def next(): String = primaryKeysResultSet.getString("COLUMN_NAME")
+        }.toList
+        connection.close()
+        tableName -> (tableRemarks, selectedColumns, primaryKeys)
+      }
+    selectedTablesAndColumns
+  }
+
+  def extractDomain(
+    jdbcSchema: JDBCSchema,
+    domainTemplate: Option[Domain],
+    selectedTablesAndColumns: Map[String, (TableRemarks, Columns, PrimaryKeys)]
+  ) = {
+    val schemaMetadata =
+      domainTemplate.flatMap(_.schemas.headOption.flatMap(_.metadata))
+    val cometSchema = selectedTablesAndColumns.map {
+      case (tableName, (tableRemarks, selectedColumns, primaryKeys)) =>
+        Schema(
+          name = tableName,
+          pattern = Pattern.compile(s"$tableName.*"),
+          attributes = selectedColumns,
+          metadata = schemaMetadata,
+          merge = None,
+          comment = Option(tableRemarks),
+          presql = None,
+          postsql = None,
+          primaryKey = if (primaryKeys.isEmpty) None else Some(primaryKeys)
+        )
+    }
+    // Generate the domain with a dummy watch directory
+    val incomingDir = domainTemplate
+      .map { dom =>
+        DatasetArea
+          .substituteDomainAndSchemaInPath(jdbcSchema.schema, "", dom.directory)
+          .toString
+      }
+      .getOrElse(s"/${jdbcSchema.schema}")
+
+    Domain(
+      jdbcSchema.schema,
+      incomingDir,
+      domainTemplate.flatMap(_.metadata),
+      None,
+      cometSchema.toList,
+      None,
+      domainTemplate.flatMap(_.extensions),
+      domainTemplate.flatMap(_.ack)
+    )
+  }
+
+  private def sparkType(jdbcType: Int, tableName: String, colName: String): String = {
+    val sqlType = reverseSqlTypes.getOrElse(jdbcType, s"UNKNOWN JDBC TYPE => $jdbcType")
+    jdbcType match {
+      case VARCHAR | CHAR | LONGVARCHAR          => "string"
+      case BIT | BOOLEAN                         => "boolean"
+      case DOUBLE | FLOAT | REAL                 => "double"
+      case NUMERIC | DECIMAL                     => "decimal"
+      case TINYINT | SMALLINT | INTEGER | BIGINT => "long"
+      case DATE                                  => "date"
+      case TIMESTAMP                             => "timestamp"
+      case TIMESTAMP_WITH_TIMEZONE =>
+        logger.warn(s"forced conversion for $tableName.$colName from $sqlType to timestamp")
+        "timestamp"
+      case VARBINARY | BINARY =>
+        logger.warn(s"forced conversion for $tableName.$colName from $sqlType to string")
+        "string"
+      case _ =>
+        logger.error(
+          s"""unsupported column type for $tableName.$colName  -> $sqlType ($jdbcType)"""
+        )
+        sqlType
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    DDL2Yml.run(args)
+  }
+}

--- a/src/main/scala/com/ebiznext/comet/schema/generator/DDLUtils.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/DDLUtils.scala
@@ -193,9 +193,9 @@ object DDLUtils extends LazyLogging {
 
           def next(): String = primaryKeysResultSet.getString("COLUMN_NAME")
         }.toList
-        connection.close()
         tableName -> (tableRemarks, selectedColumns, primaryKeys)
       }
+    connection.close()
     selectedTablesAndColumns
   }
 

--- a/src/main/scala/com/ebiznext/comet/schema/generator/Xls2YmlConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/Xls2YmlConfig.scala
@@ -45,8 +45,8 @@ object Xls2YmlConfig extends CliConfig[Xls2YmlConfig] {
     val builder = OParser.builder[Xls2YmlConfig]
     import builder._
     OParser.sequence(
-      programName("comet xls2yml"),
-      head("comet", "xls2yml", "[options]"),
+      programName("starlake xls2yml"),
+      head("starlake", "xls2yml", "[options]"),
       note(""),
       opt[Seq[String]]("files")
         .action((x, c) => c.copy(files = x))

--- a/src/main/scala/com/ebiznext/comet/schema/generator/Yml2DDLConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/Yml2DDLConfig.scala
@@ -1,0 +1,83 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
+package com.ebiznext.comet.schema.generator
+
+import com.ebiznext.comet.utils.CliConfig
+import scopt.OParser
+
+case class Yml2DDLConfig(
+  datawarehouse: String = "",
+  outputPath: Option[String] = None,
+  connection: Option[String] = None,
+  domain: Option[String] = None,
+  schemas: Option[Seq[String]] = None,
+  catalog: Option[String] = None,
+  apply: Boolean = false
+)
+
+object Yml2DDLConfig extends CliConfig[Yml2DDLConfig] {
+  val parser: OParser[Unit, Yml2DDLConfig] = {
+    val builder = OParser.builder[Yml2DDLConfig]
+    import builder._
+    OParser.sequence(
+      programName("starlake infer-ddl"),
+      head("starlake", "infer-ddl", "[options]"),
+      note(""),
+      opt[String]("datawarehouse")
+        .action((x, c) => c.copy(datawarehouse = x))
+        .required()
+        .text("target datawarehouse name (ddl mapping key in types.yml"),
+      opt[String]("connection")
+        .action((x, c) => c.copy(connection = Some(x)))
+        .optional()
+        .text("JDBC connection name with at least read write on database schema"),
+      opt[String]("output")
+        .action((x, c) => c.copy(outputPath = Some(x)))
+        .optional()
+        .text("Where to output the generated files. ./$datawarehouse/ by default"),
+      opt[String]("catalog")
+        .action((x, c) => c.copy(catalog = Some(x)))
+        .optional()
+        .text("Database Catalog if any"),
+      opt[String]("domain")
+        .action((x, c) => c.copy(domain = Some(x)))
+        .optional()
+        .text("Domain to create DDL for. ALl by default")
+        .children(
+          opt[Seq[String]]("schemas")
+            .action((x, c) => c.copy(schemas = Some(x)))
+            .optional()
+            .text("List of schemas to generate DDL for. All by default")
+        ),
+      opt[Unit]("apply")
+        .action((x, c) => c.copy(apply = true))
+        .optional()
+        .text("Does the file contain a header (For CSV files only)")
+    )
+  }
+
+  /** @param args
+    *   args list passed from command line
+    * @return
+    *   Option of case class InferDDLConfig.
+    */
+  def parse(args: Seq[String]): Option[Yml2DDLConfig] =
+    OParser.parse(parser, args, Yml2DDLConfig())
+}

--- a/src/main/scala/com/ebiznext/comet/schema/generator/Yml2DDLJob.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/Yml2DDLJob.scala
@@ -1,0 +1,114 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
+
+package com.ebiznext.comet.schema.generator
+
+import com.ebiznext.comet.config.Settings
+import com.ebiznext.comet.schema.generator.DDLUtils.{Columns, PrimaryKeys, TableRemarks}
+import com.ebiznext.comet.schema.handlers.SchemaHandler
+import org.fusesource.scalate.{TemplateEngine, TemplateSource}
+
+import scala.util.Try
+
+/** * Infers the schema of a given datapath, domain name, schema name.
+  */
+class Yml2DDLJob(config: Yml2DDLConfig, schemaHandler: SchemaHandler)(implicit
+  settings: Settings
+) {
+  val engine: TemplateEngine = new TemplateEngine
+
+  def name: String = "InferDDL"
+
+  /** Just to force any spark job to implement its entry point using within the "run" method
+    *
+    * @return
+    *   : Spark Session used for the job
+    */
+  def run(): Try[Unit] =
+    Try {
+      val domains = config.domain match {
+        case None => schemaHandler.domains
+        case Some(domain) =>
+          val res = schemaHandler.domains
+            .find(_.name.toLowerCase() == domain)
+            .getOrElse(throw new Exception(s"Domain ${domain} not found"))
+          List(res)
+      }
+      domains.map { domain =>
+        val schemas = config.schemas match {
+          case Some(schemas) =>
+            schemas.flatMap(schema =>
+              domain.schemas.find(_.name.toLowerCase() == schema.toLowerCase)
+            )
+          case None =>
+            domain.schemas
+        }
+        val existingTables = config.connection match {
+          case Some(connection) =>
+            DDLUtils.extractJDBCTables(
+              JDBCSchema(
+                connection,
+                config.catalog,
+                domain.name,
+                Nil,
+                List("TABLE"),
+                None
+              )
+            )
+          case None => Map.empty[String, (TableRemarks, Columns, PrimaryKeys)]
+        }
+        val oldTables = existingTables.keys.filter(table => schemas.map(_.name).contains(table))
+        oldTables.foreach { table =>
+          println(s"table $table need to be dropped")
+        }
+        schemas.map { schema =>
+          val ddlFields = schema.ddlMapping(config.datawarehouse, schemaHandler)
+          val attributes = ddlFields.map(_.toMap())
+          val mergedMetadata = schema.mergedMetadata(domain.metadata)
+          val isNew = existingTables.contains(schema.name.toUpperCase())
+          isNew match {
+            case false =>
+              val (existingTableRemarks, existingColumns, existingPKs) =
+                existingTables(schema.name.toUpperCase())
+
+            case true =>
+              val paramMap = Map(
+                "attributes"    -> attributes,
+                "domain"        -> domain.name,
+                "schema"        -> schema.name,
+                "partitions"    -> mergedMetadata.partition.map(_.getAttributes()).getOrElse(Nil),
+                "clustered"     -> mergedMetadata.clustering.getOrElse(Nil),
+                "primaryKeys"   -> schema.primaryKey.getOrElse(Nil),
+                "comment"       -> schema.comment.getOrElse(""),
+                "domainComment" -> domain.comment.getOrElse("")
+              )
+              val (templatePath, templateContent) =
+                domain.ddlMapping(schema, config.datawarehouse, "create")
+              val result =
+                engine.layout(
+                  TemplateSource.fromText(templatePath.toString, templateContent),
+                  paramMap
+                )
+              println(result)
+          }
+        }
+      }
+    }
+}

--- a/src/main/scala/com/ebiznext/comet/schema/generator/Yml2GraphVizConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/Yml2GraphVizConfig.scala
@@ -14,8 +14,8 @@ object Yml2GraphVizConfig extends CliConfig[Yml2GraphVizConfig] {
     val builder = OParser.builder[Yml2GraphVizConfig]
     import builder._
     OParser.sequence(
-      programName("comet yml2gv"),
-      head("comet", "yml2gv", "[options]"),
+      programName("starlake yml2gv"),
+      head("starlake", "yml2gv", "[options]"),
       note("Generate GraphViz files from Domain / Schema YAML files"),
       opt[String]("output")
         .action((x, c) => c.copy(output = Some(x)))

--- a/src/main/scala/com/ebiznext/comet/schema/generator/Yml2XlsConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/Yml2XlsConfig.scala
@@ -35,8 +35,8 @@ object Yml2XlsConfig extends CliConfig[Yml2XlsConfig] {
     val builder = OParser.builder[Yml2XlsConfig]
     import builder._
     OParser.sequence(
-      programName("comet yml2xls"),
-      head("comet", "yml2xls", "[options]"),
+      programName("starlake yml2xls"),
+      head("starlake", "yml2xls", "[options]"),
       note(""),
       opt[Seq[String]]("domain")
         .action((x, c) => c.copy(domains = x))

--- a/src/main/scala/com/ebiznext/comet/schema/model/Attribute.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Attribute.scala
@@ -202,6 +202,7 @@ case class Attribute(
           this.getFinalName(),
           attrs.map(_.ddlMapping(false, datawarehouse, schemaHandler)),
           required,
+          isArray(),
           comment
         )
       case None =>

--- a/src/main/scala/com/ebiznext/comet/schema/model/DDLMapping.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/DDLMapping.scala
@@ -1,0 +1,36 @@
+package com.ebiznext.comet.schema.model
+
+trait DDLField {
+  def toMap(): Map[String, Any]
+}
+case class DDLLeaf(
+  name: String,
+  tpe: String,
+  required: Boolean,
+  comment: Option[String],
+  primaryKey: Boolean
+) extends DDLField {
+  override def toMap(): Map[String, Any] = {
+    Map(
+      "nodeType"   -> "leaf",
+      "name"       -> name,
+      "type"       -> tpe,
+      "required"   -> required.toString,
+      "comment"    -> comment.getOrElse(""),
+      "primaryKey" -> primaryKey.toString
+    )
+  }
+}
+
+case class DDLNode(name: String, fields: List[DDLField], required: Boolean, comment: Option[String])
+    extends DDLField {
+  override def toMap(): Map[String, Any] = {
+    Map(
+      "type"     -> "node",
+      "name"     -> name,
+      "fields"   -> fields.map(_.toMap()),
+      "required" -> required.toString,
+      "comment"  -> comment.getOrElse("")
+    )
+  }
+}

--- a/src/main/scala/com/ebiznext/comet/schema/model/DDLMapping.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/DDLMapping.scala
@@ -22,12 +22,19 @@ case class DDLLeaf(
   }
 }
 
-case class DDLNode(name: String, fields: List[DDLField], required: Boolean, comment: Option[String])
-    extends DDLField {
+case class DDLNode(
+  name: String,
+  fields: List[DDLField],
+  required: Boolean,
+  isArray: Boolean,
+  comment: Option[String]
+) extends DDLField {
   override def toMap(): Map[String, Any] = {
+    val tpe = if (isArray) "ARRAY" else "STRUCT"
     Map(
-      "type"     -> "node",
+      "nodeType" -> "node",
       "name"     -> name,
+      "type"     -> tpe,
       "fields"   -> fields.map(_.toMap()),
       "required" -> required.toString,
       "comment"  -> comment.getOrElse("")

--- a/src/main/scala/com/ebiznext/comet/schema/model/Types.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Types.scala
@@ -62,7 +62,8 @@ case class Type(
   zone: Option[String] = None,
   sample: Option[String] = None,
   comment: Option[String] = None,
-  indexMapping: Option[IndexMapping] = None
+  indexMapping: Option[IndexMapping] = None,
+  ddlMapping: Option[Map[String, String]] = None
 ) {
 
   @JsonIgnore

--- a/src/main/scala/com/ebiznext/comet/utils/CliConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/CliConfig.scala
@@ -16,7 +16,7 @@ trait CliConfig[T] {
     val descriptionOptionDef = synopsisOptionDef.flatMap(_ => optionDefs.drop(2).headOption)
     val options = descriptionOptionDef.map(_ => optionDefs.drop(3)).getOrElse(Nil)
 
-    val programName = programNameOptionDef.map(_.desc.substring("comet ".length)).getOrElse("")
+    val programName = programNameOptionDef.map(_.desc.substring("starlake ".length)).getOrElse("")
     val synopsis = synopsisOptionDef.map(_.desc).getOrElse("")
     val rawDescription = descriptionOptionDef
       .map(_.desc)

--- a/src/main/scala/com/ebiznext/comet/workflow/ImportConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/ImportConfig.scala
@@ -11,8 +11,8 @@ object ImportConfig extends CliConfig[ImportConfig] {
     val builder = OParser.builder[ImportConfig]
     import builder._
     OParser.sequence(
-      programName("comet import"),
-      head("comet", "import"),
+      programName("starlake import"),
+      head("starlake", "import"),
       note("""
           |Move the files from the landing area to the pending area.
           |

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -23,6 +23,7 @@ package com.ebiznext.comet.workflow
 import better.files.File
 import com.ebiznext.comet.config.{DatasetArea, Settings}
 import com.ebiznext.comet.job.atlas.{AtlasConfig, AtlasJob}
+import com.ebiznext.comet.job.ddl.Yml2DDLJob
 import com.ebiznext.comet.job.index.bqload.{BigQueryLoadConfig, BigQuerySparkJob}
 import com.ebiznext.comet.job.index.connectionload.{ConnectionLoadConfig, ConnectionLoadJob}
 import com.ebiznext.comet.job.index.esload.{ESLoadConfig, ESLoadJob}
@@ -32,6 +33,7 @@ import com.ebiznext.comet.job.ingest._
 import com.ebiznext.comet.job.load.LoadStrategy
 import com.ebiznext.comet.job.metrics.{MetricsConfig, MetricsJob}
 import com.ebiznext.comet.job.transform.AutoTaskJob
+import com.ebiznext.comet.schema.generator.{Yml2DDLConfig, Yml2DDLJob}
 import com.ebiznext.comet.schema.handlers.{LaunchHandler, SchemaHandler, StorageHandler}
 import com.ebiznext.comet.schema.model.Format._
 import com.ebiznext.comet.schema.model._
@@ -499,7 +501,7 @@ class IngestionWorkflow(
     }
   }
 
-  def infer(config: InferSchemaConfig): Try[Unit] = {
+  def inferSchema(config: InferSchemaConfig): Try[Unit] = {
     val result = new InferSchema(
       config.domainName,
       config.schemaName,
@@ -507,6 +509,11 @@ class IngestionWorkflow(
       config.outputPath,
       config.header
     ).run()
+    Utils.logFailure(result, logger)
+  }
+
+  def inferDDL(config: Yml2DDLConfig): Try[Unit] = {
+    val result = new Yml2DDLJob(config, schemaHandler).run()
     Utils.logFailure(result, logger)
   }
 

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -23,7 +23,6 @@ package com.ebiznext.comet.workflow
 import better.files.File
 import com.ebiznext.comet.config.{DatasetArea, Settings}
 import com.ebiznext.comet.job.atlas.{AtlasConfig, AtlasJob}
-import com.ebiznext.comet.job.ddl.Yml2DDLJob
 import com.ebiznext.comet.job.index.bqload.{BigQueryLoadConfig, BigQuerySparkJob}
 import com.ebiznext.comet.job.index.connectionload.{ConnectionLoadConfig, ConnectionLoadJob}
 import com.ebiznext.comet.job.index.esload.{ESLoadConfig, ESLoadJob}

--- a/src/main/scala/com/ebiznext/comet/workflow/TransformConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/TransformConfig.scala
@@ -17,8 +17,8 @@ object TransformConfig extends CliConfig[TransformConfig] {
     val builder = OParser.builder[TransformConfig]
     import builder._
     OParser.sequence(
-      programName("comet transform | job"),
-      head("comet", "transform | job", "[options]"),
+      programName("starlake transform | job"),
+      head("starlake", "transform | job", "[options]"),
       note(""),
       opt[String]("name")
         .action((x, c) => c.copy(name = x))

--- a/src/main/scala/com/ebiznext/comet/workflow/WatchConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/WatchConfig.scala
@@ -16,8 +16,8 @@ object WatchConfig extends CliConfig[WatchConfig] {
     val builder = OParser.builder[WatchConfig]
     import builder._
     OParser.sequence(
-      programName("comet watch"),
-      head("comet", "watch", "[options]"),
+      programName("starlake watch"),
+      head("starlake", "watch", "[options]"),
       note(""),
       opt[Seq[String]]("include")
         .action((x, c) => c.copy(includes = x))

--- a/src/test/resources/quickstart/metadata/types/default.comet.yml
+++ b/src/test/resources/quickstart/metadata/types/default.comet.yml
@@ -5,37 +5,69 @@ types:
     pattern: ".+"
     sample: "Hello World"
     comment: "Any set of chars"
+    ddlMapping:
+      sql:
+      bigquery: STRING
+      snowflake: STRING
   - name: "byte"
     primitiveType: "byte"
     pattern: "."
     sample: "x"
     comment: "Any set of chars"
+    ddlMapping:
+      sql:
+      bigquery: INT64
+      snowflake: CLOB
   - name: "date"
     primitiveType: "date"
     pattern: "yyyy-MM-dd"
     sample: "2018-07-21"
     comment: "Date in the format yyyy-MM-dd"
+    ddlMapping:
+      sql:
+      bigquery: DATE
+      snowflake: DATE
   - name: "double"
     primitiveType: "double"
     pattern: "-?\\d*\\.{0,1}\\d+"
     sample: "-45.78"
     comment: "Any flating value"
+    ddlMapping:
+      sql:
+      bigquery: FLOAT64
+      snowflake: DOUBLE
   - name: "decimal"
     primitiveType: "decimal"
     pattern: "-?\\d*\\.{0,1}\\d+"
     sample: "-45.787686786876"
     comment: "Any flating value"
+    ddlMapping:
+      sql:
+      bigquery: NUMERIC
+      snowflake: DECIMAL
   - name: "long"
     primitiveType: "long"
     pattern: "-?\\d+"
     sample: "-64564"
     comment: "any positive or negative number"
+    ddlMapping:
+      sql:
+      bigquery: INT64
+      snowflake: INTEGER
   - name: "boolean"
     primitiveType: "boolean"
     pattern: "(?i)true|yes|[y1]<-TF->(?i)false|no|[n0]"
     sample: "TruE"
+    ddlMapping:
+      sql:
+      bigquery: BOOL
+      snowflake: BOOLEAN
   - name: "datetime"
     primitiveType: "timestamp"
     pattern: "yyyy-MM-dd HH:mm:ss"
     sample: "2019-12-31 23:59:02"
     comment: "date/time in epoch millis"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP

--- a/src/test/resources/sample/ddl/bigquery/alter.ssp
+++ b/src/test/resources/sample/ddl/bigquery/alter.ssp
@@ -1,0 +1,97 @@
+<%@ val attributes: List[Map[String, Any]] %>
+<%@ val newAttributes: List[Map[String, Any]] %>
+<%@ val alterAttributes: List[Map[String, Any]] %>
+<%@ val alterCommentAttributes: List[Map[String, Any]] %>
+<%@ val alterRequiredAttributes: List[Map[String, Any]] %>
+<%@ val alterDataTypeAttributes: List[Map[String, Any]] %>
+<%@ val droppedAttributes: List[Map[String, Any]] %>
+<%@ val domain: String %>
+<%@ val domainComment: String = ""  %>
+<%@ val schema: String %>
+<%@ val schemaComment: String = ""  %>
+<%@ val partitions: List[String] %>
+<%@ val clustered: List[String] %>
+<%@ val primaryKeys: List[String] %>
+
+
+<%
+    def attributeDDL(attr:Map[String, Any]):String = {
+    val required = if (attr("required").toString.toBoolean) "NOT NULL" else ""
+    val attrName = attr("name")
+    val attrType = attr("type")
+
+    attr("nodeType") match {
+    case "leaf" =>
+    s"""$attrName $attrType $required"""
+    case "node" =>
+    val fields = attr("fields").asInstanceOf[List[Map[String, Any]]]
+    val ddlFields = fields.map(field => attributeDDL(field)).mkString(",")
+    s"""$attrName $attrType<$ddlFields> $required"""
+    case _ => throw new Exception("Should never happen")
+    }
+    }
+%>
+
+
+ALTER TABLE ${domain}.${schema}
+#{
+    val attributesCount = attributes.length
+    var attributesIndex = 1
+}#
+#for (attribute <- newAttributes)
+    #{
+        val attributeComment = attribute("comment")
+        val attributeSuffix = if (attributesIndex == attributesCount) "" else ","
+        attributesIndex = attributesIndex + 1
+    }#
+    ADD COLUMN IF NOT EXISTS ${attributeDDL(attribute)} options(description="${attributeComment}")${attributeSuffix}
+#end
+)
+options(description="${domainComment}");
+
+ALTER TABLE ${domain}.${schema}
+#{
+    val attributesCount = attributes.length
+    var attributesIndex = 1
+}#
+
+#for (attribute <- droppedAttributes)
+    #{
+        val attributeSuffix = if (attributesIndex == attributesCount) "" else ","
+        attributesIndex = attributesIndex + 1
+    }#
+    DROP COLUMN IF EXISTS ${attribute("name")}${attributeSuffix}
+#end
+)
+
+#for (attribute <- alterCommentAttributes)
+    #{
+        val attributeComment = attribute("comment")
+        val attributeSuffix = if (attributesIndex == attributesCount) "" else ","
+        attributesIndex = attributesIndex + 1
+    }#
+    ALTER COLUMN IF EXISTS ${attribute("name")} SET OPTIONS(description = ${attributeComment})${attributeSuffix}
+#end
+)
+
+#for (attribute <- alterRequiredAttributes)
+    #{
+        val attributeRequired = attribute("required").toString.toBoolean
+        assert(!attributeRequired)
+        val attributeSuffix = if (attributesIndex == attributesCount) "" else ","
+        attributesIndex = attributesIndex + 1
+    }#
+    ALTER COLUMN IF EXISTS ${attribute("name")} "DROP NOT NULL"${attributeSuffix}
+#end
+)
+
+#for (attribute <- alterDataTypeAttributes)
+    #{
+        val attributeType = attribute("type")
+        val attributeSuffix = if (attributesIndex == attributesCount) "" else ","
+        attributesIndex = attributesIndex + 1
+    }#
+    ALTER COLUMN IF EXISTS ${attribute("name")} SET DATA TYPE ${attributeType}${attributeSuffix}
+#end
+)
+

--- a/src/test/resources/sample/ddl/bigquery/create.ssp
+++ b/src/test/resources/sample/ddl/bigquery/create.ssp
@@ -1,0 +1,44 @@
+<%@ val attributes: List[Map[String, Any]] %>
+<%@ val domain: String %>
+<%@ val domainComment: String = ""  %>
+<%@ val schema: String %>
+<%@ val schemaComment: String = ""  %>
+<%@ val partitions: List[String] %>
+<%@ val clustered: List[String] %>
+<%@ val primaryKeys: List[String] %>
+<%
+    val isPrimaryKeyDefined: Boolean  = !primaryKeys.isEmpty
+    val isPartitionDefined: Boolean = !partitions.isEmpty
+
+    def genAttrs(i: Int): String = {
+      if (i > 0) "-" + genAttrs(i-1) else "*"
+    }
+
+    val genRes = genAttrs(100)
+%>
+
+${genRes}
+
+#if (isPrimaryKeyDefined)
+    #for (primaryKey <- primaryKeys)
+        ${primaryKey}
+    #end
+#end
+
+#if (isPartitionDefined)
+    #for (partition <- partitions)
+        ${partition}
+    #end
+#end
+
+CREATE TABLE ${domain}.${schema}
+#for (attribute <- attributes)
+    #if (attribute("nodeType") == "leaf")
+        ${attribute("name")} ${attribute("type")} ${attribute("required")} ${attribute("comment")} ${attribute("comment")}
+    #else
+      STRUCT< >
+    #end
+#end
+
+
+${genRes}

--- a/src/test/resources/sample/ddl/bigquery/create.ssp
+++ b/src/test/resources/sample/ddl/bigquery/create.ssp
@@ -1,4 +1,10 @@
 <%@ val attributes: List[Map[String, Any]] %>
+<%@ val newAttributes: List[Map[String, Any]] %>
+<%@ val alterAttributes: List[Map[String, Any]] %>
+<%@ val alterCommentAttributes: List[Map[String, Any]] %>
+<%@ val alterRequiredAttributes: List[Map[String, Any]] %>
+<%@ val alterDataTypeAttributes: List[Map[String, Any]] %>
+<%@ val droppedAttributes: List[Map[String, Any]] %>
 <%@ val domain: String %>
 <%@ val domainComment: String = ""  %>
 <%@ val schema: String %>
@@ -7,17 +13,26 @@
 <%@ val clustered: List[String] %>
 <%@ val primaryKeys: List[String] %>
 <%
-    val isPrimaryKeyDefined: Boolean  = !primaryKeys.isEmpty
-    val isPartitionDefined: Boolean = !partitions.isEmpty
+    val isPrimaryKeyDefined: Boolean  = primaryKeys.nonEmpty
+    val isPartitionDefined: Boolean = partitions.nonEmpty
 
-    def genAttrs(i: Int): String = {
-      if (i > 0) "-" + genAttrs(i-1) else "*"
+    def attributeDDL(attr:Map[String, Any]):String = {
+        val required = if (attr("required").toString.toBoolean) "NOT NULL" else ""
+        val attrName = attr("name")
+        val attrType = attr("type")
+
+        attr("nodeType") match {
+            case "leaf" =>
+                s"""$attrName $attrType $required"""
+            case "node" =>
+              val fields = attr("fields").asInstanceOf[List[Map[String, Any]]]
+                val ddlFields = fields.map(field => attributeDDL(field)).mkString(",")
+                s"""$attrName $attrType<$ddlFields> $required"""
+            case _ => throw new Exception("Should never happen")
+        }
     }
-
-    val genRes = genAttrs(100)
 %>
 
-${genRes}
 
 #if (isPrimaryKeyDefined)
     #for (primaryKey <- primaryKeys)
@@ -31,14 +46,19 @@ ${genRes}
     #end
 #end
 
-CREATE TABLE ${domain}.${schema}
+CREATE TABLE ${domain}.${schema} (
+#{
+    val attributesCount = attributes.length
+    var attributesIndex = 1
+}#
 #for (attribute <- attributes)
-    #if (attribute("nodeType") == "leaf")
-        ${attribute("name")} ${attribute("type")} ${attribute("required")} ${attribute("comment")} ${attribute("comment")}
-    #else
-      STRUCT< >
-    #end
+    #{
+        val attributeComment = attribute("comment")
+        val attributeSuffix = if (attributesIndex == attributesCount) "" else ","
+        attributesIndex = attributesIndex + 1
+    }#
+    ${attributeDDL(attribute)} options(description="${attributeComment}")${attributeSuffix}
 #end
+)
+options(description="${domainComment}");
 
-
-${genRes}

--- a/src/test/resources/sample/ddl/bigquery/drop.ssp
+++ b/src/test/resources/sample/ddl/bigquery/drop.ssp
@@ -1,0 +1,18 @@
+<%@ val attributes: List[Map[String, Any]] %>
+<%@ val newAttributes: List[Map[String, Any]] %>
+<%@ val alterAttributes: List[Map[String, Any]] %>
+<%@ val alterCommentAttributes: List[Map[String, Any]] %>
+<%@ val alterRequiredAttributes: List[Map[String, Any]] %>
+<%@ val alterDataTypeAttributes: List[Map[String, Any]] %>
+<%@ val droppedAttributes: List[Map[String, Any]] %>
+<%@ val domain: String %>
+<%@ val domainComment: String = ""  %>
+<%@ val schema: String %>
+<%@ val schemaComment: String = ""  %>
+<%@ val partitions: List[String] %>
+<%@ val clustered: List[String] %>
+<%@ val primaryKeys: List[String] %>
+
+
+drop table  ${domain}.${schema};
+

--- a/src/test/resources/sample/default.comet.yml
+++ b/src/test/resources/sample/default.comet.yml
@@ -5,112 +5,195 @@ types:
     pattern: ".+"
     sample: "Hello World"
     comment: "Any set of chars"
+    ddlMapping:
+      sql:
+      bigquery: STRING
+      snowflake: STRING
   - name: "int"
     pattern: "[-|\\+|0-9][0-9]*"
     primitiveType: "long"
     sample: "1234"
     comment: "Int number"
+    ddlMapping:
+      sql:
+      bigquery: INT64
+      snowflake: INT
   - name: "byte"
     primitiveType: "byte"
     pattern: "."
     sample: "x"
     comment: "Any set of chars"
+    ddlMapping:
+      sql:
+      bigquery: INT64
+      snowflake: INT
   - name: "double"
     primitiveType: "double"
     pattern: "-?\\d*\\.{0,1}\\d+"
     sample: "-45.78"
     comment: "Any flating value"
-  - name: "double"
-    primitiveType: "double"
-    pattern: "-?\\d*\\.{0,1}\\d+"
-    sample: "-45.787686786876"
-    comment: "Any flating value"
+    ddlMapping:
+      sql:
+      bigquery: FLOAT64
+      snowflake: DOUBLE
   - name: "long"
     primitiveType: "long"
     pattern: "-?\\d+"
     sample: "-64564"
     comment: "any positive or negative number"
+    ddlMapping:
+      sql:
+      bigquery: INT64
+      snowflake: INTEGER
   - name: "short"
     primitiveType: "short"
     pattern: "-?\\d+"
     sample: "564"
     comment: "any positive or negative number"
+    ddlMapping:
+      sql:
+      bigquery: INT64
+      snowflake: INTEGER
   - name: "boolean"
     primitiveType: "boolean"
     pattern: "(?i)true|yes|[y1]<-TF->(?i)false|no|[n0]"
     sample: "TruE"
+    ddlMapping:
+      sql:
+      bigquery: BOOL
+      snowflake: BOOLEAN
   - name: "timestamp"
     primitiveType: "timestamp"
     pattern: "yyyy-MM-dd HH:mm:ss"
     sample: "2018-07-21 12:21:22"
     comment: "date/time in epoch millis"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "decimal"
     primitiveType: "decimal"
     pattern: "-?\\d*\\.{0,1}\\d+"
     sample: "-45.787686786876"
     comment: "Any floating value"
+    ddlMapping:
+      sql:
+      bigquery: NUMERIC
+      snowflake: DECIMAL
   - name: "date"
     primitiveType: "date"
     pattern: "yyyy-MM-dd"
     sample: "2018-07-21"
     comment: "Date in the format yyyy-MM-dd"
+    ddlMapping:
+      sql:
+      bigquery: DATE
+      snowflake: DATE
   - name: "basic_iso_date"
     primitiveType: "timestamp"
     pattern: "BASIC_ISO_DATE"
     sample: "20111203"
     comment: "Timestamp based on yyyMMdd pattern"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "iso_local_date"
     primitiveType: "timestamp"
     pattern: "ISO_LOCAL_DATE"
     sample: "2011-12-03"
     comment: "Timestamp based on yyyy-MM-dd pattern"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "iso_offset_date"
     primitiveType: "timestamp"
     pattern: "ISO_OFFSET_DATE"
     sample: "2011-12-03+02:00"
     comment: "Timestamp based on `ISO Date with offset` pattern"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "iso_date"
     primitiveType: "timestamp"
     pattern: "ISO_DATE"
     sample: "2011-12-03+02:00"
     comment: "Timestamp based on `ISO Date with or without offset` pattern"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "iso_local_date_time"
     primitiveType: "timestamp"
     pattern: "ISO_LOCAL_DATE_TIME"
     sample: "2011-12-03T10:15:30"
     comment: "Timestamp based on `ISO Local Date and Time` pattern"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "iso_offset_date_time"
     primitiveType: "timestamp"
     pattern: "ISO_OFFSET_DATE_TIME"
     sample: "2011-12-03T10:15:30+01:00"
     comment: "Timestamp based on `ISO Local Date and Time` pattern"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "iso_zoned_date_time"
     primitiveType: "timestamp"
     pattern: "ISO_ZONED_DATE_TIME"
     sample: "2011-12-03T10:15:30+01:00[Europe/Paris]"
     comment: "Timestamp based on `ISO Zoned Date Time` pattern"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "iso_date_time"
     primitiveType: "timestamp"
     pattern: "ISO_DATE_TIME"
     sample: "2011-12-03T10:15:30+01:00[Europe/Paris]"
     comment: "Timestamp based on `ISO Date and time with ZoneId` pattern"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "iso_ordinal_date"
     primitiveType: "timestamp"
     pattern: "ISO_ORDINAL_DATE"
     sample: "2012-337"
     comment: "Timestamp based on `year and day of year` pattern"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "iso_week_date"
     primitiveType: "timestamp"
     pattern: "ISO_WEEK_DATE"
     sample: "2012-W48-6"
     comment: "Timestamp based on `Year and Week` pattern"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "iso_instant"
     primitiveType: "timestamp"
     pattern: "ISO_INSTANT"
     sample: "2011-12-03T10:15:30Z"
     comment: "Timestamp based on `Date and Time of an Instant` pattern (UTC only)"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "rfc_1123_date_time"
     primitiveType: "timestamp"
     pattern: "RFC_1123_DATE_TIME"
     sample: "Tue, 3 Jun 2008 11:05:30 GMT"
     comment: "Timestamp based on `RFC 1123 / RFC 822` patterns"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP

--- a/src/test/resources/sample/position/position.comet.yml
+++ b/src/test/resources/sample/position/position.comet.yml
@@ -24,6 +24,7 @@ schemas:
         type: "byte"
         required: true
         privacy: "NONE"
+        comment:  "simple description"
         position:
           first: 0
           last: 0

--- a/src/test/resources/sample/types.comet.yml
+++ b/src/test/resources/sample/types.comet.yml
@@ -5,42 +5,82 @@ types:
     pattern: "yyyy-MM-dd HH:mm:ss"
     sample: "2019-12-31 23:59:02"
     comment: "date/time in epoch millis"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: time
     pattern: "(1[012]|[1-9]):[0-5][0-9](\\\\s)?(?i)(am|pm)"
     primitiveType: "string"
+    ddlMapping:
+      sql:
+      bigquery: STRING
+      snowflake: STRING
   - name: time24
     pattern: "([01]?[0-9]|2[0-3]):[0-5][0-9]"
     primitiveType: "string"
+    ddlMapping:
+      sql:
+      bigquery: STRING
+      snowflake: STRING
   - name: username
     pattern: "[a-z0-9_-]{3,15}"
     primitiveType: "string"
+    ddlMapping:
+      sql:
+      bigquery: STRING
+      snowflake: STRING
   - name: datefr
     primitiveType: "date"
     pattern: "dd.MM.yyyy"
     sample: "21.07.2018"
     comment: "Data in the format dd.MM.yyyy"
+    ddlMapping:
+      sql:
+      bigquery: DATE
+      snowflake: DATE
   - name: email
     primitiveType: string
     pattern: "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}"
     sample: me@company.com
     comment: Valid email only
+    ddlMapping:
+      sql:
+      bigquery: STRING
+      snowflake: STRING
   - name: date_fr
     primitiveType: date
     pattern: "dd/MM/yyyy"
     sample: 21/07/2018
     comment: Date in the format dd/MM/yyyy
+    ddlMapping:
+      sql:
+      bigquery: DATE
+      snowflake: DATE
   - name: date_fr2
     primitiveType: date
     pattern: "dd.MM.yyyy"
     sample: 21.07.2018
     comment: Date in the format dd.MM.yyyy
+    ddlMapping:
+      sql:
+      bigquery: DATE
+      snowflake: DATE
   - name: "epoch_second"
     primitiveType: "timestamp"
     pattern: "epoch_second"
     sample: "1631562304"
     comment: "date/time in epoch seconds"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP
   - name: "epoch_milli"
     primitiveType: "timestamp"
     pattern: "epoch_milli"
     sample: "1631562304000"
     comment: "date/time in epoch milliseconds"
+    ddlMapping:
+      sql:
+      bigquery: TIMESTAMP
+      snowflake: TIMESTAMP

--- a/src/test/scala/com/ebiznext/comet/TestHelper.scala
+++ b/src/test/scala/com/ebiznext/comet/TestHelper.scala
@@ -117,6 +117,14 @@ trait TestHelper
     )
   )
 
+  val allMappings: List[FileToImport] = List(
+    FileToImport(
+      "create.ssp",
+      "/sample/ddl/bigquery/create.ssp",
+      Some("ddl/bigquery")
+    )
+  )
+
   val allAssertions: List[FileToImport] = List(
     FileToImport(
       "default.comet.yml",
@@ -242,6 +250,17 @@ trait TestHelper
       allViews.foreach { viewToImport =>
         val assertionPath = new Path(DatasetArea.views, viewToImport.name)
         deliverTestFile(viewToImport.path, assertionPath)
+      }
+      allMappings.foreach { mappingToImport =>
+        val path = mappingToImport.folder match {
+          case None =>
+            DatasetArea.mapping.toString
+          case Some(folder) =>
+            DatasetArea.mapping.toString + "/" + folder
+        }
+        metadataStorageHandler.mkdirs(new Path(path))
+        val mappingPath = new Path(path, mappingToImport.name)
+        deliverTestFile(mappingToImport.path, mappingPath)
       }
     }
 
@@ -520,4 +539,4 @@ object TestHelper {
   private val runtimeId: String = UUID.randomUUID().toString
 }
 
-case class FileToImport(name: String, path: String)
+case class FileToImport(name: String, path: String, folder: Option[String] = None)

--- a/src/test/scala/com/ebiznext/comet/job/ddl/DDLInferSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/job/ddl/DDLInferSpec.scala
@@ -1,0 +1,33 @@
+package com.ebiznext.comet.job.ddl
+
+import com.ebiznext.comet.TestHelper
+import com.ebiznext.comet.schema.generator.{Yml2DDLConfig, Yml2DDLJob}
+import com.ebiznext.comet.schema.handlers.SchemaHandler
+import com.ebiznext.comet.utils.Utils
+
+class DDLInferSpec extends TestHelper {
+
+  "Infer Create BQ Table" should "succeed" in {
+    import org.slf4j.impl.StaticLoggerBinder
+    val binder = StaticLoggerBinder.getSingleton
+    logger.debug(binder.getLoggerFactory.toString)
+    logger.debug(binder.getLoggerFactoryClassStr)
+
+    new WithSettings() {
+      new SpecTrait(
+        domainOrJobFilename = "position.comet.yml",
+        sourceDomainOrJobPathname = "/sample/position/position.comet.yml",
+        datasetDomainName = "position",
+        sourceDatasetPathName = "/sample/position/XPOSTBL"
+      ) {
+        val schemaHandler = new SchemaHandler(metadataStorageHandler)
+        cleanMetadata
+        cleanDatasets
+        val config = Yml2DDLConfig("bigquery")
+        val result = new Yml2DDLJob(config, schemaHandler).run()
+        Utils.logFailure(result, logger)
+      }
+
+    }
+  }
+}

--- a/src/test/scala/com/ebiznext/comet/schema/generator/DDL2YmlSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/generator/DDL2YmlSpec.scala
@@ -31,6 +31,7 @@ class DDL2YmlSpec extends TestHelper {
 
       val metadata = Metadata(mode = Some(Mode.STREAM), quote = Some("::"))
       val domainTemplate = Domain("CUSTOM_NAME", "/{domain}/{schema}", metadata = Some(metadata))
+      val config = DDL2YmlConfig()
       DDL2Yml.run(JDBCSchema("test-h2", None, "PUBLIC", Nil), File("/tmp"), Some(domainTemplate))
       val domain = YamlSerializer.deserializeDomain(File("/tmp", "PUBLIC.comet.yml")) match {
         case Success(domain) => domain
@@ -166,6 +167,7 @@ class DDL2YmlSpec extends TestHelper {
         File("/tmp"),
         None
       )
+
       val domain = YamlSerializer.deserializeDomain(File("/tmp", "PUBLIC.comet.yml")) match {
         case Success(domain) => domain
         case Failure(e)      => throw e

--- a/src/test/scala/com/ebiznext/comet/schema/generator/Yml2DDLSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/generator/Yml2DDLSpec.scala
@@ -1,11 +1,12 @@
-package com.ebiznext.comet.job.ddl
+package com.ebiznext.comet.schema.generator
 
 import com.ebiznext.comet.TestHelper
-import com.ebiznext.comet.schema.generator.{Yml2DDLConfig, Yml2DDLJob}
 import com.ebiznext.comet.schema.handlers.SchemaHandler
 import com.ebiznext.comet.utils.Utils
 
-class DDLInferSpec extends TestHelper {
+import scala.util.{Failure, Success}
+
+class Yml2DDLSpec extends TestHelper {
 
   "Infer Create BQ Table" should "succeed" in {
     import org.slf4j.impl.StaticLoggerBinder
@@ -25,7 +26,10 @@ class DDLInferSpec extends TestHelper {
         cleanDatasets
         val config = Yml2DDLConfig("bigquery")
         val result = new Yml2DDLJob(config, schemaHandler).run()
-        Utils.logFailure(result, logger)
+        Utils.logFailure(result, logger) match {
+          case Failure(exception) => throw exception
+          case Success(_)         => // do nothing
+        }
       }
 
     }

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
@@ -571,7 +571,7 @@ class SchemaHandlerSpec extends TestHelper {
             |}
         """.stripMargin.trim
         val mapping =
-          schema.map(_.mapping(None, "locations", schemaHandler)).map(_.trim).getOrElse("")
+          schema.map(_.esMapping(None, "locations", schemaHandler)).map(_.trim).getOrElse("")
         logger.info(mapping)
         mapping.replaceAll("\\s", "") shouldBe expected.replaceAll("\\s", "")
       }


### PR DESCRIPTION
## Summary
Many Database including Snowflake and other relational databases require the table schema to be created upfront.
Even when addressing BigQuery, some users would like the schema to be created upfront too even though it is not required.

This feature would add a new command that would create the required DDL. We call this command infer-ddl.
Databases usually evolve in time. This command should also address the issue of altering the table schema if it already exist in the database.

// Use mapping specifict BigQuery and generate create/alter table statements
starlake.sh infer-ddl --datawarehouse bigquery --connection bq

// Use mapping default mapping and generate create/alter table statements
starlake.sh infer-ddl --connection bq
starlake.sh infer-ddl --datawarehouse sql --connection bq --output ./sql

// use default mapping and generate and apply create/alter table statements
starlake.sh infer-ddl --datawarehouse sql --connection bq --apply

// use default mapping and generate and apply create/alter table statements using the provided moustache template
starlake.sh infer-ddl --datawarehouse sql --template my template.mustache --connection bq --apply

**Related Issue: #50**

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**



