### PR TITLE
Get rid of RDD

### DIFF
--- a/src/main/scala/ai/starlake/job/ingest/DsvIngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/DsvIngestionJob.scala
@@ -21,11 +21,9 @@
 package ai.starlake.job.ingest
 
 import ai.starlake.config.Settings
-import ai.starlake.job.validator.ValidationResult
 import ai.starlake.schema.handlers.{SchemaHandler, StorageHandler}
 import ai.starlake.schema.model._
 import org.apache.hadoop.fs.Path
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.types.StructType
 
@@ -188,7 +186,7 @@ class DsvIngestionJob(
     * @param dataset
     *   : Spark Dataset
     */
-  protected def ingest(dataset: DataFrame): (RDD[_], RDD[_]) = {
+  protected def ingest(dataset: DataFrame): (Dataset[String], Dataset[Row]) = {
 
     val orderedAttributes = reorderAttributes(dataset)
 
@@ -214,17 +212,7 @@ class DsvIngestionJob(
     )
 
     saveRejected(validationResult.errors, validationResult.rejected)
-    saveAccepted(validationResult.accepted, orderedSparkTypes, validationResult)
+    saveAccepted(validationResult)
     (validationResult.errors, validationResult.accepted)
   }
-
-  protected def saveAccepted(
-    acceptedRDD: RDD[Row],
-    orderedSparkTypes: StructType,
-    validationResult: ValidationResult
-  ): (DataFrame, Path) = {
-    val acceptedDF = session.createDataFrame(acceptedRDD, orderedSparkTypes)
-    super.saveAccepted(acceptedDF, validationResult)
-  }
-
 }

--- a/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
@@ -999,7 +999,7 @@ object IngestionUtil {
     // We need to save first the application ID
     // refrencing it inside the worker (rdd.map) below would fail.
     val applicationId = session.sparkContext.applicationId
-    val rejectedTypedRDD = rejectedDS.map { err =>
+    val rejectedTypedDS = rejectedDS.map { err =>
       RejectedRecord(
         applicationId,
         now,
@@ -1011,7 +1011,7 @@ object IngestionUtil {
     }
     val rejectedDF = session
       .createDataFrame(
-        rejectedTypedRDD.toDF().rdd,
+        rejectedTypedDS.toDF().rdd,
         StructType(
           rejectedCols.map { case (attrName, _, sparkType) =>
             StructField(attrName, sparkType, nullable = false)

--- a/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
@@ -1,32 +1,5 @@
 package ai.starlake.job.ingest
 
-import ai.starlake.job.index.bqload.BigQuerySparkJob
-import ai.starlake.job.index.connectionload.ConnectionLoadConfig
-import ai.starlake.job.validator.{GenericRowValidator, ValidationResult}
-import ai.starlake.schema.handlers.{SchemaHandler, StorageHandler}
-import ai.starlake.schema.model.Engine.SPARK
-import ai.starlake.schema.model.Rejection.ColResult
-import ai.starlake.schema.model.Stage.UNIT
-import ai.starlake.schema.model.Trim.{BOTH, LEFT, RIGHT}
-import ai.starlake.schema.model.WriteMode.APPEND
-import ai.starlake.schema.model.{
-  Attribute,
-  BigQuerySink,
-  Domain,
-  EsSink,
-  FsSink,
-  JdbcSink,
-  MergeOptions,
-  Metadata,
-  NoneSink,
-  PrivacyLevel,
-  Schema,
-  SinkType,
-  Stage,
-  Type,
-  WriteMode
-}
-import ai.starlake.utils.conversion.BigQueryUtils
 import ai.starlake.config.{DatasetArea, Settings, StorageArea}
 import ai.starlake.job.index.bqload.{BigQueryLoadConfig, BigQueryNativeJob, BigQuerySparkJob}
 import ai.starlake.job.index.connectionload.{ConnectionLoadConfig, ConnectionLoadJob}
@@ -35,8 +8,11 @@ import ai.starlake.job.ingest.ImprovedDataFrameContext._
 import ai.starlake.job.metrics.{AssertionJob, MetricsJob}
 import ai.starlake.job.validator.{GenericRowValidator, ValidationResult}
 import ai.starlake.schema.handlers.{SchemaHandler, StorageHandler}
+import ai.starlake.schema.model.Engine.SPARK
 import ai.starlake.schema.model.Rejection.{ColInfo, ColResult}
+import ai.starlake.schema.model.Stage.UNIT
 import ai.starlake.schema.model.Trim.{BOTH, LEFT, RIGHT}
+import ai.starlake.schema.model.WriteMode.APPEND
 import ai.starlake.schema.model._
 import ai.starlake.utils.Formatter._
 import ai.starlake.utils._
@@ -54,7 +30,6 @@ import com.google.cloud.bigquery.{
 }
 import org.apache.hadoop.fs.Path
 import org.apache.spark.ml.feature.SQLTransformer
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{Metadata => _, _}
@@ -62,7 +37,6 @@ import org.apache.spark.sql.types.{Metadata => _, _}
 import java.sql.Timestamp
 import java.time.{Instant, LocalDateTime}
 import scala.collection.JavaConverters._
-import scala.language.existentials
 import scala.util.{Failure, Success, Try}
 
 trait IngestionJob extends SparkJob {
@@ -99,7 +73,7 @@ trait IngestionJob extends SparkJob {
     *
     * @param dataset
     */
-  protected def ingest(dataset: DataFrame): (RDD[_], RDD[_])
+  protected def ingest(dataset: DataFrame): (Dataset[String], Dataset[Row])
 
   @silent
   protected def applyIgnore(dfIn: DataFrame): Dataset[Row] = {
@@ -117,12 +91,12 @@ trait IngestionJob extends SparkJob {
   }
 
   protected def saveRejected(
-    errMessagesRDD: RDD[String],
-    rejectedLinesRDD: RDD[String]
+    errMessagesDS: Dataset[String],
+    rejectedLinesDS: Dataset[String]
   ): Try[Path] = {
     logger.whenDebugEnabled {
-      logger.debug(s"rejectedRDD SIZE ${errMessagesRDD.count()}")
-      errMessagesRDD.take(100).foreach(rejected => logger.debug(rejected.replaceAll("\n", "|")))
+      logger.debug(s"rejectedRDD SIZE ${errMessagesDS.count()}")
+      errMessagesDS.take(100).foreach(rejected => logger.debug(rejected.replaceAll("\n", "|")))
     }
     val domainName = domain.name
     val schemaName = schema.name
@@ -130,12 +104,13 @@ trait IngestionJob extends SparkJob {
     val start = Timestamp.from(Instant.now())
     val formattedDate = new java.text.SimpleDateFormat("yyyyMMddHHmmss").format(start)
 
-    if (settings.comet.sinkReplayToFile && !rejectedLinesRDD.isEmpty()) {
+    if (settings.comet.sinkReplayToFile && rejectedLinesDS.limit(1).count() > 0) {
       val replayArea = DatasetArea.replay(domainName)
       val targetPath =
         new Path(replayArea, s"$domainName.$schemaName.$formattedDate.replay")
-      rejectedLinesRDD
+      rejectedLinesDS
         .coalesce(1)
+        .rdd
         .saveAsTextFile(targetPath.toString)
       storageHandler.moveSparkPartFile(
         targetPath,
@@ -143,7 +118,7 @@ trait IngestionJob extends SparkJob {
       )
     }
 
-    IngestionUtil.sinkRejected(session, errMessagesRDD, domainName, schemaName, now) match {
+    IngestionUtil.sinkRejected(session, errMessagesDS, domainName, schemaName, now) match {
       case Success((rejectedDF, rejectedPath)) =>
         // We sink to a file when running unit tests
         if (settings.comet.sinkToFile) {
@@ -275,11 +250,10 @@ trait IngestionJob extends SparkJob {
     * @param acceptedDF
     */
   protected def saveAccepted(
-    dataframe: DataFrame,
     validationResult: ValidationResult
   ): (DataFrame, Path) = {
-    if (!settings.comet.rejectAllOnError || validationResult.rejected.isEmpty()) {
-      val acceptedDF = dfWithAttributesRenamed(dataframe)
+    if (!settings.comet.rejectAllOnError || validationResult.rejected.limit(1).count() == 0) {
+      val acceptedDF = dfWithAttributesRenamed(validationResult.accepted)
       val start = Timestamp.from(Instant.now())
       logger.whenDebugEnabled {
         logger.debug(s"acceptedRDD SIZE ${acceptedDF.count()}")
@@ -402,13 +376,9 @@ trait IngestionJob extends SparkJob {
         logger.debug(acceptedDfWithoutIgnoredFields.schemaString())
       }
       val finalSchema = schema.finalSparkSchema(schemaHandler)
-
       // adding computed columns can change the order of columns, we must force the order defined in the schema
-      val orderedWithScriptFieldsDF =
-        session.createDataFrame(
-          acceptedDfWithoutIgnoredFields.select(finalSchema.map(attr => col(attr.name)): _*).rdd,
-          finalSchema
-        )
+      val cols = schema.attributes.map(attr => col(attr.getFinalName()))
+      val orderedWithScriptFieldsDF = acceptedDfWithoutIgnoredFields.select(cols: _*)
       logger.whenDebugEnabled {
         logger.debug("Accepted Dataframe schema after applying the defined schema")
         logger.debug(orderedWithScriptFieldsDF.schemaString())
@@ -1019,7 +989,7 @@ object IngestionUtil {
 
   def sinkRejected(
     session: SparkSession,
-    rejectedRDD: RDD[String],
+    rejectedDS: Dataset[String],
     domainName: String,
     schemaName: String,
     now: Timestamp
@@ -1030,7 +1000,7 @@ object IngestionUtil {
     // We need to save first the application ID
     // refrencing it inside the worker (rdd.map) below would fail.
     val applicationId = session.sparkContext.applicationId
-    val rejectedTypedRDD = rejectedRDD.map { err =>
+    val rejectedTypedRDD = rejectedDS.map { err =>
       RejectedRecord(
         applicationId,
         now,

--- a/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
@@ -375,9 +375,8 @@ trait IngestionJob extends SparkJob {
         logger.debug("Accepted Dataframe schema right after adding computed columns")
         logger.debug(acceptedDfWithoutIgnoredFields.schemaString())
       }
-      val finalSchema = schema.finalSparkSchema(schemaHandler)
       // adding computed columns can change the order of columns, we must force the order defined in the schema
-      val cols = schema.attributes.map(attr => col(attr.getFinalName()))
+      val cols = schema.finalAttributeNames().map(col)
       val orderedWithScriptFieldsDF = acceptedDfWithoutIgnoredFields.select(cols: _*)
       logger.whenDebugEnabled {
         logger.debug("Accepted Dataframe schema after applying the defined schema")

--- a/src/main/scala/ai/starlake/job/ingest/PositionIngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/PositionIngestionJob.scala
@@ -20,15 +20,12 @@
 
 package ai.starlake.job.ingest
 
-import ai.starlake.schema.handlers.{SchemaHandler, StorageHandler}
-import ai.starlake.schema.model.{Domain, Schema, Type}
 import ai.starlake.config.Settings
 import ai.starlake.schema.handlers.{SchemaHandler, StorageHandler}
 import ai.starlake.schema.model._
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.mapred.TextInputFormat
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
@@ -95,7 +92,7 @@ class PositionIngestionJob(
     * @param input
     *   : Spark Dataset
     */
-  override protected def ingest(input: DataFrame): (RDD[_], RDD[_]) = {
+  override protected def ingest(input: DataFrame): (Dataset[String], Dataset[Row]) = {
 
     val dataset: DataFrame =
       PositionIngestionUtil.prepare(session, input, schema.attributesWithoutScriptedFields)
@@ -123,7 +120,7 @@ class PositionIngestionJob(
       orderedSparkTypes
     )
     saveRejected(validationResult.errors, validationResult.rejected)
-    saveAccepted(validationResult.accepted, orderedSparkTypes, validationResult)
+    saveAccepted(validationResult)
     (validationResult.errors, validationResult.accepted)
   }
 

--- a/src/main/scala/ai/starlake/job/metrics/MetricsJob.scala
+++ b/src/main/scala/ai/starlake/job/metrics/MetricsJob.scala
@@ -1,13 +1,10 @@
 package ai.starlake.job.metrics
 
+import ai.starlake.config.{DatasetArea, Settings}
 import ai.starlake.job.metrics.Metrics.{ContinuousMetric, DiscreteMetric, MetricsDatasets}
 import ai.starlake.schema.handlers.{SchemaHandler, StorageHandler}
 import ai.starlake.schema.model.Engine.SPARK
 import ai.starlake.schema.model.{Domain, Schema, Stage}
-import ai.starlake.config.{DatasetArea, Settings}
-import ai.starlake.job.metrics.Metrics.{ContinuousMetric, DiscreteMetric, MetricsDatasets}
-import ai.starlake.schema.handlers.{SchemaHandler, StorageHandler}
-import ai.starlake.schema.model._
 import ai.starlake.utils._
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql._

--- a/src/main/scala/ai/starlake/job/validator/AcceptAllValidator.scala
+++ b/src/main/scala/ai/starlake/job/validator/AcceptAllValidator.scala
@@ -1,11 +1,9 @@
 package ai.starlake.job.validator
 
-import ai.starlake.schema.model.{Attribute, Type}
 import ai.starlake.config.Settings
 import ai.starlake.schema.model.{Attribute, Format, Type}
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 object AcceptAllValidator extends GenericRowValidator {
 
@@ -18,9 +16,10 @@ object AcceptAllValidator extends GenericRowValidator {
     types: List[Type],
     sparkType: StructType
   )(implicit settings: Settings): ValidationResult = {
-    val rejectedRDD: RDD[String] = session.emptyDataFrame.rdd.map(_.mkString)
-    val rejectedInputRDD: RDD[String] = session.emptyDataFrame.rdd.map(_.mkString)
-    val acceptedRDD: RDD[Row] = dataset.rdd
-    ValidationResult(rejectedRDD, rejectedInputRDD, acceptedRDD)
+    import session.implicits._
+    val rejectedDS = session.emptyDataset[String]
+    val rejectedInputDS = session.emptyDataset[String]
+    val acceptedDS = dataset
+    ValidationResult(rejectedDS, rejectedInputDS, acceptedDS)
   }
 }

--- a/src/main/scala/ai/starlake/job/validator/GenericRowValidator.scala
+++ b/src/main/scala/ai/starlake/job/validator/GenericRowValidator.scala
@@ -1,16 +1,14 @@
 package ai.starlake.job.validator
 
-import ai.starlake.schema.model.{Attribute, Type}
 import ai.starlake.config.Settings
 import ai.starlake.schema.model.{Attribute, Format, Type}
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 
 case class ValidationResult(
-  errors: RDD[String],
-  rejected: RDD[String],
-  accepted: RDD[Row]
+  errors: Dataset[String],
+  rejected: Dataset[String],
+  accepted: Dataset[Row]
 )
 
 trait GenericRowValidator {

--- a/src/main/scala/ai/starlake/schema/model/Schema.scala
+++ b/src/main/scala/ai/starlake/schema/model/Schema.scala
@@ -259,7 +259,7 @@ case class Schema(
     p: Attribute => Boolean
   ): StructType = {
     val fields = attributes filter p map { attr =>
-      StructField(attr.rename.getOrElse(attr.name), attr.sparkType(schemaHandler), !attr.required)
+      StructField(attr.getFinalName(), attr.sparkType(schemaHandler), !attr.required)
         .withComment(attr.comment.getOrElse(""))
     }
     StructType(fields)

--- a/src/main/scala/ai/starlake/schema/model/Schema.scala
+++ b/src/main/scala/ai/starlake/schema/model/Schema.scala
@@ -280,6 +280,9 @@ case class Schema(
     }
   }
 
+  def finalAttributeNames(): List[String] =
+    attributes.filterNot(_.isIgnore()).map(attr => attr.getFinalName())
+
   /** Check attribute definition correctness :
     *   - schema name should be a valid table identifier
     *   - attribute name should be a valid Hive column identifier


### PR DESCRIPTION
## Summary
We get rid of the RDD everywhere except in the validators where we manipulate objects of type Any since we are having generic validators here.

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**

