### PR TITLE
Update jackson

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -14,7 +14,7 @@ object Versions {
   val log4s = "1.3.3"
   val betterFiles = "3.9.1"
   val jackson211ForSpark2 = "2.6.7"
-  val jackson212ForSpark3 = "2.10.0"
+  val jackson212ForSpark3 = "2.12.3"
   val pureConfig = "0.14.0"
   val esSpark211 = "7.8.1"
   val esSpark212 = "7.16.2"

--- a/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
@@ -27,6 +27,7 @@ import ai.starlake.utils.{CometObjectMapper, Utils, YamlSerializer}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.github.ghik.silencer.silent
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.hadoop.fs.Path
 
@@ -42,7 +43,7 @@ import scala.util.{Failure, Success, Try}
 class SchemaHandler(storage: StorageHandler)(implicit settings: Settings) extends StrictLogging {
 
   // uses Jackson YAML for parsing, relies on SnakeYAML for low level handling
-  val mapper: ObjectMapper with ScalaObjectMapper =
+  @silent val mapper: ObjectMapper with ScalaObjectMapper =
     new CometObjectMapper(new YAMLFactory(), injectables = (classOf[Settings], settings) :: Nil)
 
   @throws[Exception]

--- a/src/main/scala/ai/starlake/utils/CometObjectMapper.scala
+++ b/src/main/scala/ai/starlake/utils/CometObjectMapper.scala
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.{InjectableValues, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.github.ghik.silencer.silent
 
 object CometObjectMapper {
 
@@ -15,6 +16,7 @@ object CometObjectMapper {
 
 }
 
+@silent
 class CometObjectMapper(
   jf: JsonFactory = null,
   injectables: scala.collection.immutable.Seq[(Class[_], AnyRef)] = Nil

--- a/src/test/scala/ai/starlake/TestHelper.scala
+++ b/src/test/scala/ai/starlake/TestHelper.scala
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.github.ghik.silencer.silent
 import com.typesafe.config._
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.commons.io.FileUtils
@@ -204,7 +205,7 @@ trait TestHelper
     def metadataStorageHandler = settings.storageHandler
     def storageHandler = settings.storageHandler
 
-    lazy val mapper: ObjectMapper with ScalaObjectMapper = {
+    @silent val mapper: ObjectMapper with ScalaObjectMapper = {
       val mapper = new CometObjectMapper(new YAMLFactory(), (classOf[Settings], settings) :: Nil)
       mapper
     }


### PR DESCRIPTION
We keep the obsolete ScalaObjectMapper to keep support for spark 2.4.8
