### PR TITLE
drop scala 2.11 support

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -35,5 +35,3 @@ jobs:
         run: gcloud info
       - name: Publish Snapshot on Sonatype Spark 2/3 for scala 2.12
         run: COMET_ACCESS_POLICIES_PROJECT_ID=${{ secrets.GCP_PROJECT }} TEMPORARY_GCS_BUCKET=starlake-app COMET_GCP_TEST=true RELEASE_SONATYPE=true GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} SONATYPE_USERNAME=${{ secrets.SONATYPE_USERNAME }} SONATYPE_PASSWORD=${{ secrets.SONATYPE_PASSWORD }} sbt ++2.12.12 test publish
-      - name: Publish Snapshot on Sonatype Spark 2/3 for scala 2.11
-        run: COMET_ACCESS_POLICIES_PROJECT_ID=${{ secrets.GCP_PROJECT }} TEMPORARY_GCS_BUCKET=starlake-app COMET_GCP_TEST=true RELEASE_SONATYPE=true GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} SONATYPE_USERNAME=${{ secrets.SONATYPE_USERNAME }} SONATYPE_PASSWORD=${{ secrets.SONATYPE_PASSWORD }} sbt ++2.11.12 publish

--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,7 @@ sonatypeCredentialHost := "s01.oss.sonatype.org"
 
 lazy val scala212 = "2.12.12"
 
-lazy val scala211 = "2.11.12"
-
-crossScalaVersions := List(scala211, scala212)
+crossScalaVersions := List(scala212)
 
 organization := "ai.starlake"
 
@@ -33,11 +31,6 @@ libraryDependencies ++= {
   val (spark, jackson, esSpark) = {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 12)) => (spark_3d0_forScala_2d12, jackson212ForSpark3, esSpark212)
-      case Some((2, 11)) =>
-        sys.env.getOrElse("COMET_HDP31", "false").toBoolean match {
-          case false => (spark_2d4_forScala_2d11, jackson211ForSpark2, esSpark211)
-          case true  => (spark_2d4_forScala_2d11, jackson211ForSpark2Hdp31, esSpark211)
-        }
       case _ => throw new Exception(s"Invalid Scala Version")
     }
   }
@@ -48,7 +41,6 @@ name := {
   val sparkNameSuffix = {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 12)) => "3"
-      case Some((2, 11)) => "2"
       case _             => throw new Exception(s"Invalid Scala Version")
     }
   }

--- a/docs/docs/cloud/file.md
+++ b/docs/docs/cloud/file.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 6
-title: On Premise Hadoop Cluster
+title: Local filesystem for testing
 ---
 
 

--- a/docs/docs/cloud/hadoop.md
+++ b/docs/docs/cloud/hadoop.md
@@ -1,4 +1,4 @@
 ---
 sidebar_position: 5
-title: Local filesystem for testing
+title: On Premise Hadoop Cluster
 ---

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,37 +44,12 @@ object Dependencies {
 
   // Provided
 
-  val jackson211ForSpark2 = Seq(
-    "com.fasterxml.jackson.core" % "jackson-core" % Versions.jackson211ForSpark2 % "provided",
-    "com.fasterxml.jackson.core" % "jackson-annotations" % Versions.jackson211ForSpark2 % "provided",
-    "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson211ForSpark2 % "provided",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions.jackson211ForSpark2 % "provided",
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson211ForSpark2 % "provided"
-  )
-
-  val jackson211ForSpark2Hdp31 = Seq(
-    "com.fasterxml.jackson.core" % "jackson-core" % Versions.jackson212ForSpark3 % "provided",
-    "com.fasterxml.jackson.core" % "jackson-annotations" % Versions.jackson212ForSpark3 % "provided",
-    "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson212ForSpark3 % "provided",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions.jackson212ForSpark3 % "provided",
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson212ForSpark3 % "provided"
-  )
-
   val jackson212ForSpark3 = Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % Versions.jackson212ForSpark3 % "provided",
     "com.fasterxml.jackson.core" % "jackson-annotations" % Versions.jackson212ForSpark3 % "provided",
     "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson212ForSpark3 % "provided",
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions.jackson212ForSpark3 % "provided",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson212ForSpark3 % "provided"
-  )
-
-  val spark_2d4_forScala_2d11 = Seq(
-    "org.apache.spark" %% "spark-core" % Versions.spark2d4 % "provided" excludeAll (jacksonExclusions: _*) exclude ("com.google.guava", "guava"),
-    "org.apache.spark" %% "spark-sql" % Versions.spark2d4 % "provided" excludeAll (jacksonExclusions: _*) exclude ("com.google.guava", "guava"),
-    "org.apache.spark" %% "spark-hive" % Versions.spark2d4 % "provided" excludeAll (jacksonExclusions: _*) exclude ("com.google.guava", "guava"),
-    "org.apache.spark" %% "spark-mllib" % Versions.spark2d4 % "provided" excludeAll (jacksonExclusions: _*) exclude ("com.google.guava", "guava"),
-    "com.databricks" %% "spark-xml" % Versions.sparkXML,
-    "org.apache.spark" %% "spark-sql-kafka-0-10" % Versions.spark2d4 % "provided"
   )
 
   val spark_3d0_forScala_2d12 = Seq(
@@ -135,11 +110,6 @@ object Dependencies {
     // Add the jar file to spark dependencies
     "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.23.1" % "provided" excludeAll (jacksonExclusions: _*),
     "com.google.cloud" % "google-cloud-datacatalog" % Versions.gcpDataCatalog excludeAll (jacksonExclusions: _*)
-  )
-
-  val esSpark211 = Seq(
-    "org.elasticsearch" %% "elasticsearch-spark-20" % Versions.esSpark211 % "provided" exclude ("com.google.guava", "guava") excludeAll ((sparkExclusions ++ jacksonExclusions): _*),
-    "com.dimafeng" %% "testcontainers-scala-elasticsearch" % Versions.testContainers % Test excludeAll (jnaExclusions: _*)
   )
 
   val esSpark212 = Seq(


### PR DESCRIPTION
## Summary
Scala 2.11 is no more supported. Last supported version is 0.2.8-SNAPSHOT

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? Yes**




