### PR TITLE
Support any generic Spark source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 __New feature__:
 - Drop support for Spark 2.3.X
 - Allow table renaming on write
-- Any Spark supported input is now allowed
+- Any Spark supported input in FULL mode
 - Env vars in env.yml files
 
 __Bug Fix__:

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.9"
+ThisBuild / version := "0.2.10-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.9-SNAPSHOT"
+ThisBuild / version := "0.2.9"


### PR DESCRIPTION
## Summary
metadat.mode=generic allow to specify the source in the options field.

**PR Type: Feature **

**Status: Ready to review**

**Breaking change? No**
