### PR TITLE
Feature/scheduling

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -100,6 +100,16 @@ csv-output = ${?COMET_CSV_OUTPUT}
 csv-output-ext = ""
 csv-output-ext = ${?COMET_CSV_OUTPUT_EXT}
 
+
+scheduling {
+  mode = "FAIR"
+  mode = "FIFO"
+  weight = 1
+  minShare = 0
+  maxJobs = 1
+  allocations=""
+}
+
 privacy {
   options {
     "none": "ai.starlake.privacy.No",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -102,12 +102,10 @@ csv-output-ext = ${?COMET_CSV_OUTPUT_EXT}
 
 
 scheduling {
-  mode = "FAIR"
+  max-jobs = 1
   mode = "FIFO"
-  weight = 1
-  minShare = 0
-  maxJobs = 1
-  allocations=""
+  file = ""
+  pool-name = "default"
 }
 
 privacy {

--- a/src/main/scala/ai/starlake/config/Settings.scala
+++ b/src/main/scala/ai/starlake/config/Settings.scala
@@ -207,6 +207,14 @@ object Settings extends StrictLogging {
     customDeserializer: Option[String]
   )
 
+  case class JobScheduling(
+    mode: String,
+    weight: Int,
+    minShare: Int,
+    maxJobs: Int,
+    allocations: String
+  )
+
   case class AccessPolicies(apply: Boolean, location: String, projectId: String, taxonomy: String)
 
   /** @param datasets
@@ -282,7 +290,8 @@ object Settings extends StrictLogging {
     rejectAllOnError: Boolean,
     defaultFileExtensions: String,
     forceFileExtensions: String,
-    accessPolicies: AccessPolicies
+    accessPolicies: AccessPolicies,
+    scheduling: JobScheduling
   ) extends Serializable {
 
     val cacheStorageLevel =

--- a/src/main/scala/ai/starlake/config/Settings.scala
+++ b/src/main/scala/ai/starlake/config/Settings.scala
@@ -346,13 +346,13 @@ object Settings extends StrictLogging {
     val applicationConfPath = new Path(DatasetArea.metadata(settings), "application.conf")
     val result: Settings = if (settings.metadataStorageHandler.exists(applicationConfPath)) {
       val applicationConfContent = settings.metadataStorageHandler.read(applicationConfPath)
-      val cfg = ConfigFactory.parseString(applicationConfContent)
-      val effectiveApplicationConfig = cfg
+      val applicationConfig = ConfigFactory.parseString(applicationConfContent)
+      val effectiveApplicationConfig = applicationConfig
         .withFallback(effectiveConfig)
-      val loadedApplication = ConfigSource
+      val mergedSettings = ConfigSource
         .fromConfig(effectiveApplicationConfig)
         .loadOrThrow[Comet]
-      Settings(loadedApplication, effectiveApplicationConfig.getConfig("spark"))
+      Settings(mergedSettings, effectiveApplicationConfig.getConfig("spark"))
     } else
       settings
     val jobConf = initSparkConfig(result)

--- a/src/main/scala/ai/starlake/config/SparkEnv.scala
+++ b/src/main/scala/ai/starlake/config/SparkEnv.scala
@@ -20,14 +20,9 @@
 
 package ai.starlake.config
 
-import better.files.File
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import scala.collection.JavaConverters._
 
 /** Any Spark Job will inherit from this class. All properties defined in application conf file and
   * prefixed by the "spark" key will be loaded into the Spark Job
@@ -40,59 +35,9 @@ class SparkEnv(name: String, confTransformer: SparkConf => SparkConf = identity)
   settings: Settings
 ) extends StrictLogging {
 
-  private def initSchedulingConfig(): File = {
-    import settings.comet.scheduling._
-
-    val schedulingConfig =
-      if (allocations.isEmpty)
-        s"""<?xml version="1.0"?>
-                     |<allocations>
-                     |  <pool name="starlake">
-                     |    <schedulingMode>$mode</schedulingMode>
-                     |    <weight>$weight}</weight>
-                     |    <minShare>$minShare</minShare>
-                     |  </pool>
-                     |</allocations>""".stripMargin
-      else
-        allocations
-
-    val tempFile = File.temp / "starlake-spark-scheduling.xml"
-    tempFile.overwrite(schedulingConfig)
-  }
-
   /** Load spark.* properties from the loaded application conf file
     */
-  val config: SparkConf = {
-    val schedulingConfig = initSchedulingConfig()
-    val now = LocalDateTime
-      .now()
-      .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss.SSS"))
-    val appName = s"$name-$now"
-
-    // When using local Spark with remote BigQuery (useful for testing)
-    val initialConf =
-      sys.env.get("TEMPORARY_GCS_BUCKET") match {
-        case Some(value) => new SparkConf().set("temporaryGcsBucket", value)
-        case None        => new SparkConf()
-      }
-
-    val thisConf = settings.sparkConfig
-      .entrySet()
-      .asScala
-      .to[Vector]
-      .map(x => (x.getKey, x.getValue.unwrapped().toString))
-      .foldLeft(initialConf) { case (conf, (key, value)) => conf.set("spark." + key, value) }
-      .setAppName(appName)
-      .set("spark.app.id", appName)
-      .set("spark.scheduler.allocation.file", schedulingConfig.uri.toString)
-
-    val withExtraConf = confTransformer(thisConf)
-
-    logger.whenDebugEnabled {
-      logger.debug(withExtraConf.toDebugString)
-    }
-    withExtraConf
-  }
+  val config: SparkConf = confTransformer(settings.jobConf)
 
   /** Creates a Spark Session with the spark.* keys defined the application conf file.
     */
@@ -107,5 +52,4 @@ class SparkEnv(name: String, confTransformer: SparkConf => SparkConf = identity)
     logger.info(session.conf.getAll.mkString("\n"))
     session
   }
-
 }

--- a/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
@@ -844,6 +844,11 @@ trait IngestionJob extends SparkJob {
     *   : Spark Session used for the job
     */
   def run(): Try[JobResult] = {
+    session.sparkContext.setLocalProperty(
+      "spark.scheduler.pool",
+      settings.comet.scheduling.poolName
+    )
+
     val jobResult = domain.checkValidity(schemaHandler) match {
       case Left(errors) =>
         val errs = errors.reduce { (errs, err) =>

--- a/src/main/scala/ai/starlake/utils/Job.scala
+++ b/src/main/scala/ai/starlake/utils/Job.scala
@@ -65,7 +65,7 @@ trait JobBase extends StrictLogging with DatasetLogging {
 
 trait SparkJob extends JobBase {
 
-  def withExtraSparkConf(sourceConfig: SparkConf): SparkConf = {
+  protected def withExtraSparkConf(sourceConfig: SparkConf): SparkConf = {
     // During Job execution, schema update are done on the table before data is written
     // These two options below are thus disabled.
     // We disable them because even though the user asked for WRITE_APPEND
@@ -76,7 +76,7 @@ trait SparkJob extends JobBase {
     sourceConfig
   }
 
-  lazy val sparkEnv: SparkEnv = {
+  private lazy val sparkEnv: SparkEnv = {
     new SparkEnv(name, withExtraSparkConf)
   }
 

--- a/src/main/scala/ai/starlake/utils/Job.scala
+++ b/src/main/scala/ai/starlake/utils/Job.scala
@@ -12,6 +12,8 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.IntegerType
 
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import scala.util.{Failure, Success, Try}
 
 trait JobResult
@@ -73,12 +75,20 @@ trait SparkJob extends JobBase {
     // Moreover, since we handle schema validaty through the YAML file, we manage these settings automatically
     sourceConfig.remove("spark.datasource.bigquery.allowFieldAddition")
     sourceConfig.remove("spark.datasource.bigquery.allowFieldRelaxation")
-    sourceConfig
+
+    val now = LocalDateTime
+      .now()
+      .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss.SSS"))
+
+    val appName = s"$name-$now"
+    val thisConf = sourceConfig.setAppName(appName).set("spark.app.id", appName)
+    logger.whenDebugEnabled {
+      logger.debug(thisConf.toDebugString)
+    }
+    thisConf
   }
 
-  private lazy val sparkEnv: SparkEnv = {
-    new SparkEnv(name, withExtraSparkConf)
-  }
+  private lazy val sparkEnv: SparkEnv = new SparkEnv(name, withExtraSparkConf)
 
   protected def registerUdf(udf: String): Unit = {
     val udfInstance: UdfRegistration =

--- a/src/test/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJobSpec.scala
+++ b/src/test/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJobSpec.scala
@@ -80,29 +80,31 @@ class BigQueryNativeJobSpec extends TestHelper with BeforeAndAfterAll {
     }
 
     "Native BigQuery AutoJob" should "succeed" in {
-      val businessTask1 = AutoTaskDesc(
-        None,
-        Some("select * from bqtest.account"),
-        "bqtest",
-        "jobresult",
-        WriteMode.OVERWRITE,
-        sink = Some(BigQuerySink(name = Some("sinktest"), location = Some("EU"))),
-        engine = Some(Engine.BQ)
-      )
-      val businessJob =
-        AutoJobDesc("user", List(businessTask1), None, None, None, engine = Some(Engine.BQ))
-      val schemaHandler = new SchemaHandler(metadataStorageHandler)
+      if (sys.env.getOrElse("COMET_GCP_TEST", "false").toBoolean) {
+        val businessTask1 = AutoTaskDesc(
+          None,
+          Some("select * from bqtest.account"),
+          "bqtest",
+          "jobresult",
+          WriteMode.OVERWRITE,
+          sink = Some(BigQuerySink(name = Some("sinktest"), location = Some("EU"))),
+          engine = Some(Engine.BQ)
+        )
+        val businessJob =
+          AutoJobDesc("user", List(businessTask1), None, None, None, engine = Some(Engine.BQ))
+        val schemaHandler = new SchemaHandler(metadataStorageHandler)
 
-      val businessJobDef = mapper
-        .writer()
-        .withAttribute(classOf[Settings], settings)
-        .writeValueAsString(businessJob)
-      lazy val pathBusiness = new Path(cometMetadataPath + "/jobs/bqjobtest.comet.yml")
+        val businessJobDef = mapper
+          .writer()
+          .withAttribute(classOf[Settings], settings)
+          .writeValueAsString(businessJob)
+        lazy val pathBusiness = new Path(cometMetadataPath + "/jobs/bqjobtest.comet.yml")
 
-      val workflow =
-        new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher())
-      storageHandler.write(businessJobDef, pathBusiness)
-      workflow.autoJob(TransformConfig("bqjobtest")) should be(true)
+        val workflow =
+          new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher())
+        storageHandler.write(businessJobDef, pathBusiness)
+        workflow.autoJob(TransformConfig("bqjobtest")) should be(true)
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Support Spark Fair Job Scheduling by setting the following properties:

scheduling {
   max-jobs = 1 // Max number of jobs to submit in parallel
   mode = "FIFO" // FAIR or FIFO
   file = "" // full path of the file describing the pools if not located in the metadata directory 
   pool-name = "default" // pool name to use
 }


**Related Issue: #132 **

**PR Type: Feature**

**Status:Ready to review**

**Breaking change? No**


