### PR TITLE
add include option to ImportConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+# 0.3.2
+__New feature__:
+- import step can be limited to one or more domains
+
 # 0.3.1
 __New feature__:
 - Update Kafka / BigQuery libraries

--- a/src/main/scala/ai/starlake/workflow/ImportConfig.scala
+++ b/src/main/scala/ai/starlake/workflow/ImportConfig.scala
@@ -3,7 +3,9 @@ package ai.starlake.workflow
 import ai.starlake.utils.CliConfig
 import scopt.OParser
 
-case class ImportConfig()
+case class ImportConfig(
+  includes: Seq[String] = Seq.empty
+)
 
 object ImportConfig extends CliConfig[ImportConfig] {
 
@@ -29,7 +31,12 @@ object ImportConfig extends CliConfig[ImportConfig] {
           |
           |"ack" is the default ack extension searched for but you may specify a different one in the domain YML file.
           |example: comet import
-          |""".stripMargin)
+          |""".stripMargin),
+      opt[Seq[String]]("include")
+        .action((x, c) => c.copy(includes = x))
+        .valueName("domain1,domain2...")
+        .optional()
+        .text("Domains to import")
     )
   }
 

--- a/src/main/scala/ai/starlake/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/ai/starlake/workflow/IngestionWorkflow.scala
@@ -84,9 +84,15 @@ class IngestionWorkflow(
     * file. "ack" is the default ack extension searched for but you may specify a different one in
     * the domain YML file.
     */
-  def loadLanding(): Unit = {
-    logger.info("LoadLanding")
-    domains.foreach { domain =>
+  def loadLanding(config: ImportConfig): Unit = {
+    val filteredDomains = config.includes match {
+      case Nil => domains
+      case _   => domains.filter { d => config.includes.contains(d.name) }
+    }
+    logger.info(
+      s"Loading files from Landing Zone for domains : ${filteredDomains.map(_.name).mkString(",")}"
+    )
+    filteredDomains.foreach { domain =>
       val storageHandler = settings.storageHandler
       val inputDir = new Path(domain.resolveDirectory())
       if (storageHandler.exists(inputDir)) {

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -122,8 +122,14 @@ object Main extends StrictLogging {
             false
         }
       case "import" =>
-        workflow.loadLanding()
-        true
+        ImportConfig.parse(args.drop(1)) match {
+          case Some(config) =>
+            workflow.loadLanding(config)
+            true
+          case None =>
+            println(ImportConfig.usage())
+            false
+        }
       case "validate" =>
         schemaHandler.checkValidity()
         true

--- a/src/test/scala/ai/starlake/TestHelper.scala
+++ b/src/test/scala/ai/starlake/TestHelper.scala
@@ -28,7 +28,7 @@ import ai.starlake.job.ingest.LoadConfig
 import ai.starlake.schema.handlers.{SchemaHandler, SimpleLauncher, StorageHandler}
 import ai.starlake.schema.model.AutoJobDesc
 import ai.starlake.utils.{CometObjectMapper, Utils}
-import ai.starlake.workflow.{IngestionWorkflow, WatchConfig}
+import ai.starlake.workflow.{ImportConfig, IngestionWorkflow, WatchConfig}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -45,12 +45,12 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, BeforeAndAfterAll}
 import org.testcontainers.utility.DockerImageName
-
 import java.io.{File, InputStream}
 import java.nio.file.Files
 import java.time.LocalDate
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
+
 import scala.collection.JavaConverters._
 import scala.io.{Codec, Source}
 import scala.util.Try
@@ -405,7 +405,7 @@ trait TestHelper
 
       // Load landing file
       val validator = new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher())
-      validator.loadLanding()
+      validator.loadLanding(ImportConfig())
     }
   }
 


### PR DESCRIPTION
## Summary
Add an _include_ option to `ImportConfig` that allows limiting import step to one or more domains instead of doing a global import

**PR Type: Feature**

**Status: eady to review**

**Breaking change? No**

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have updated the Release notes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



