### PR TITLE
Limit number of files grouped (rate limit exceeded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 0.3.13
 __New feature__:
 - Improve XLS support for long name
+- Handle rate limit exceeded by setting COMET_GROUPED_MAX to avoir HTTP 429 on some cloud providers. 
 
 # 0.3.12
 __Bug Fix__: reorder transformation on attributes as follows:
@@ -50,8 +51,6 @@ __New feature__:
 - Add new  [preset env vars](https://starlake-ai.github.io/starlake/docs/reference/environment#preset-variables)
 - Allow renaming of domains and schemas
 
-__Bug Fix__:
-
 # 0.3.0
 __New feature__:
 - Vars in assertions are now substituted at load time
@@ -60,15 +59,11 @@ __New feature__:
 - Add support for generic sink
 - Allow use of custom deserializer on Kafka source
 
-__Bug Fix__:
-
 # 0.2.10
 __New feature__:
 - Drop Java 1.8 prerequisite for compilation  
 - Support custom database name for Hive compatible metastore
 - Support custom dataset name in BQ
-
-__Bug Fix__:
 
 # 0.2.9
 __New feature__:
@@ -76,8 +71,6 @@ __New feature__:
 - Allow table renaming on write
 - Any Spark supported input is now allowed
 - Env vars in env.yml files
-
-__Bug Fix__:
 
 # 0.2.8
 __New feature__:

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -84,6 +84,9 @@ lock {
 grouped = false
 grouped = ${?COMET_GROUPED}
 
+grouped-max = 1000000
+grouped-max = ${?COMET_GROUPED_MAX}
+
 load-strategy-class = "ai.starlake.job.load.IngestionTimeStrategy"
 load-strategy-class = ${?COMET_LOAD_STRATEGY}
 

--- a/src/main/scala/ai/starlake/config/Settings.scala
+++ b/src/main/scala/ai/starlake/config/Settings.scala
@@ -302,6 +302,7 @@ object Settings extends StrictLogging {
     analyze: Boolean,
     hive: Boolean,
     grouped: Boolean,
+    groupedMax: Int,
     mergeForceDistinct: Boolean,
     mergeOptimizePartitionWrite: Boolean,
     area: Area,


### PR DESCRIPTION
## Summary
To handle on Cloud storage the rate limit exceeded error message, 
we now allow the number of files grouped together to be limited by configuration. 

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**


