### PR TITLE
Feature/xsd validation

### DIFF
--- a/src/main/scala/ai/starlake/job/ingest/XmlIngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/XmlIngestionJob.scala
@@ -63,14 +63,15 @@ class XmlIngestionJob(
     *   Spark Dataframe loaded using metadata options
     */
   protected def loadDataSet(): Try[DataFrame] = {
+    val xmlOptions = metadata.getXmlOptions()
     Try {
-      val rowTag = metadata.xml.flatMap(_.get("rowTag"))
+      val rowTag = xmlOptions.get("rowTag")
       rowTag.map { rowTag =>
         val df = path
           .map { singlePath =>
             session.read
               .format("com.databricks.spark.xml")
-              .option("rowTag", rowTag)
+              .options(xmlOptions)
               .option("inferSchema", value = false)
               .option("encoding", metadata.getEncoding())
               .options(metadata.getOptions())
@@ -112,7 +113,7 @@ class XmlIngestionJob(
           )
         )
         (rejectedDS, dataset)
-      case _ =>
+      case None =>
         val withInputFileNameDS =
           dataset.withColumn(CometColumns.cometInputFileNameColumn, input_file_name())
 

--- a/src/main/scala/ai/starlake/schema/model/Attribute.scala
+++ b/src/main/scala/ai/starlake/schema/model/Attribute.scala
@@ -320,3 +320,27 @@ case class Attribute(
     }
   }
 }
+
+object Attribute {
+  def apply(sparkField: StructField): Attribute = {
+    val sparkType = sparkField.dataType
+    val fieldName = sparkField.name
+    val required = !sparkField.nullable
+    val isArray = sparkType.isInstanceOf[ArrayType]
+    sparkType match {
+      case _: StructType =>
+        val struct = sparkType.asInstanceOf[StructType]
+        val subFields = struct.fields.map(field => apply(field))
+        new Attribute(
+          fieldName,
+          PrimitiveType.struct.toString,
+          Some(isArray),
+          required,
+          attributes = Some(subFields.toList)
+        )
+      case _ =>
+        val tpe = PrimitiveType.toPrimitiveType(sparkType)
+        new Attribute(fieldName, tpe.toString, Some(isArray), required)
+    }
+  }
+}

--- a/src/main/scala/ai/starlake/schema/model/Attribute.scala
+++ b/src/main/scala/ai/starlake/schema/model/Attribute.scala
@@ -339,7 +339,7 @@ object Attribute {
           attributes = Some(subFields.toList)
         )
       case _ =>
-        val tpe = PrimitiveType.toPrimitiveType(sparkType)
+        val tpe = PrimitiveType.from(sparkType)
         new Attribute(fieldName, tpe.toString, Some(isArray), required)
     }
   }

--- a/src/main/scala/ai/starlake/schema/model/Metadata.scala
+++ b/src/main/scala/ai/starlake/schema/model/Metadata.scala
@@ -152,6 +152,15 @@ case class Metadata(
   @JsonIgnore
   def getOptions(): Map[String, String] = options.getOrElse(Map.empty)
 
+  @JsonIgnore
+  def getXmlOptions(): Map[String, String] = xml.getOrElse(Map.empty)
+
+  @JsonIgnore
+  def getXsdPath(): Option[String] = {
+    val xmlOptions = xml.getOrElse(Map.empty)
+    xmlOptions.get("rowValidationXSDPath").orElse(xmlOptions.get("xsdPath"))
+  }
+
   /** Merge a single attribute
     *
     * @param parent

--- a/src/main/scala/ai/starlake/schema/model/PrimitiveType.scala
+++ b/src/main/scala/ai/starlake/schema/model/PrimitiveType.scala
@@ -362,7 +362,7 @@ object PrimitiveType {
     "RFC_1123_DATE_TIME"   -> RFC_1123_DATE_TIME
   )
 
-  def toPrimitiveType(elementType: DataType): PrimitiveType = {
+  def from(elementType: DataType): PrimitiveType = {
     elementType match {
       case _: BinaryType    => PrimitiveType.string
       case _: ByteType      => PrimitiveType.byte

--- a/src/main/scala/ai/starlake/schema/model/PrimitiveType.scala
+++ b/src/main/scala/ai/starlake/schema/model/PrimitiveType.scala
@@ -362,4 +362,23 @@ object PrimitiveType {
     "RFC_1123_DATE_TIME"   -> RFC_1123_DATE_TIME
   )
 
+  def toPrimitiveType(elementType: DataType): PrimitiveType = {
+    elementType match {
+      case _: BinaryType    => PrimitiveType.string
+      case _: ByteType      => PrimitiveType.byte
+      case _: ShortType     => PrimitiveType.short
+      case _: IntegerType   => PrimitiveType.int
+      case _: LongType      => PrimitiveType.long
+      case _: BooleanType   => PrimitiveType.boolean
+      case _: FloatType     => PrimitiveType.double
+      case _: DoubleType    => PrimitiveType.double
+      case _: DecimalType   => PrimitiveType.decimal
+      case _: StringType    => PrimitiveType.string
+      case _: TimestampType => PrimitiveType.timestamp
+      case _: DateType      => PrimitiveType.date
+      case _ =>
+        throw new IllegalArgumentException("Data type not expected: " + elementType.simpleString)
+    }
+  }
+
 }

--- a/src/main/scala/ai/starlake/schema/model/Schema.scala
+++ b/src/main/scala/ai/starlake/schema/model/Schema.scala
@@ -217,7 +217,6 @@ case class Schema(
   }
 
   def sparkSchemaUntypedEpochWithoutScriptedFields(schemaHandler: SchemaHandler): StructType = {
-    val xx = attributesWithoutScriptedFields
     val fields = attributesWithoutScriptedFields.map { attr =>
       val sparkType = attr.tpe(schemaHandler).fold(attr.sparkType(schemaHandler)) { tpe =>
         (tpe.primitiveType, tpe.pattern) match {

--- a/src/test/resources/sample/xsd/locations.comet.yml
+++ b/src/test/resources/sample/xsd/locations.comet.yml
@@ -15,7 +15,7 @@ load:
     xml:
       rowTag: element
       inferSchema: false
-      rowValidationXSDPath: /Users/hayssams/git/public/starlake/src/test/resources/sample/xsd/locations.xsd
+      rowValidationXSDPath: __COMET_TEST_ROOT__/metadata/domains/sample/xsd/locations.xsd
     partition:
       attributes:
         - comet_year

--- a/src/test/resources/sample/xsd/locations.comet.yml
+++ b/src/test/resources/sample/xsd/locations.comet.yml
@@ -1,46 +1,57 @@
 ---
-name: "locations"
-directory: "__COMET_TEST_ROOT__"
-metadata:
-  mode: "FILE"
-  format: "XML"
-  multiline: true
-  array: true
-  withHeader: true
-  separator: ""
-  quote: "\""
-  escape: "\\"
-  write: "APPEND"
-  xml:
-    rowTag: element
-    inferSchema: false
-    rowValidationXSDPath: /Users/hayssams/git/public/starlake/src/test/resources/sample/xsd/locations.xsd
-  partition:
-    attributes:
-      - comet_year
-      - comet_month
-      - comet_day
-tables:
-  - name: "locations"
-    pattern: "locations.*"
-    attributes:
-      - name: "_continent"
-        type: "string"
-        required: false
-        privacy: "MD5"
-      - name: "id"
-        type: "string"
-        required: false
-        privacy: "NONE"
-      - name: "name"
-        type: "string"
-        required: false
-        privacy: "NONE"
-      - name: "seconds"
-        type: "epoch_second"
-        required: true
-        privacy: "NONE"
-      - name: "millis"
-        type: "epoch_milli"
-        required: true
-        privacy: "NONE"
+load:
+  name: "locations"
+  directory: "__COMET_TEST_ROOT__"
+  metadata:
+    mode: "FILE"
+    format: "XML"
+    multiline: true
+    array: true
+    withHeader: true
+    separator: ""
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+    xml:
+      rowTag: element
+      inferSchema: false
+      rowValidationXSDPath: /Users/hayssams/git/public/starlake/src/test/resources/sample/xsd/locations.xsd
+    partition:
+      attributes:
+        - comet_year
+        - comet_month
+        - comet_day
+  tables:
+    - name: "locations"
+      pattern: "locations.*"
+      attributes:
+        - name: "_continent"
+          type: "string"
+          required: false
+          privacy: "MD5"
+        - name: "id"
+          type: "string"
+          required: false
+          privacy: "NONE"
+        - name: "name"
+          type: "string"
+          required: false
+          privacy: "NONE"
+        - name: "seconds"
+          type: "epoch_second"
+          required: true
+          privacy: "NONE"
+        - name: "millis"
+          type: "epoch_milli"
+          required: true
+          privacy: "NONE"
+        - name: "sub1"
+          type: "struct"
+          attributes:
+            - name: "test1"
+              type: "string"
+            - name: "sub2"
+              type: "struct"
+              attributes:
+                - name: "test2"
+                  type: "string"

--- a/src/test/resources/sample/xsd/locations.xml
+++ b/src/test/resources/sample/xsd/locations.xml
@@ -9,7 +9,7 @@
     <element continent = "Europe">
         <id>2</id>
         <name>Paris</name>
-        <secondsx>1631562191</secondsx>
+        <seconds>1631562191</seconds>
         <millis>1631562192</millis>
     </element>
 </root>

--- a/src/test/scala/ai/starlake/schema/handlers/JsonIngestionJobSpec.scala
+++ b/src/test/scala/ai/starlake/schema/handlers/JsonIngestionJobSpec.scala
@@ -112,9 +112,7 @@ abstract class JsonIngestionJobSpecBase(variant: String) extends TestHelper with
 
         cleanMetadata
         cleanDatasets
-        assertThrows[Exception] {
-          loadPending
-        }
+        loadPending shouldBe false
       }
     }
   }

--- a/src/test/scala/ai/starlake/schema/handlers/SchemaHandlerSpec.scala
+++ b/src/test/scala/ai/starlake/schema/handlers/SchemaHandlerSpec.scala
@@ -571,6 +571,7 @@ class SchemaHandlerSpec extends TestHelper {
         millis.substring(0, 4) shouldBe "1970"
       }
     }
+
     "Ingest Locations XML with XSD" should "produce file in accepted" in {
       new SpecTrait(
         domainOrJobFilename = "locations.comet.yml",
@@ -580,6 +581,11 @@ class SchemaHandlerSpec extends TestHelper {
       ) {
         cleanMetadata
         cleanDatasets
+
+        withSettings.deliverTestFile(
+          "/sample/xsd/locations.xsd",
+          new Path(domainMetadataRootPath, "sample/xsd/locations.xsd")
+        )
 
         loadPending
 
@@ -609,6 +615,7 @@ class SchemaHandlerSpec extends TestHelper {
         millis.substring(0, 4) shouldBe "1631"
       }
     }
+
     "Load Business with Transform Tag" should "load an AutoDesc" in {
       new SpecTrait(
         domainOrJobFilename = "locations.comet.yml",

--- a/src/test/scala/ai/starlake/schema/handlers/SchemaHandlerSpec.scala
+++ b/src/test/scala/ai/starlake/schema/handlers/SchemaHandlerSpec.scala
@@ -534,7 +534,6 @@ class SchemaHandlerSpec extends TestHelper {
 
     }
     "Ingest Locations XML" should "produce file in accepted" in {
-
       new SpecTrait(
         domainOrJobFilename = "locations.comet.yml",
         sourceDomainOrJobPathname = s"/sample/xml/locations.comet.yml",
@@ -570,6 +569,44 @@ class SchemaHandlerSpec extends TestHelper {
         // We just check against the year since the test may be executed in a different time zone :)
         seconds.substring(0, 4) shouldBe "2021"
         millis.substring(0, 4) shouldBe "1970"
+      }
+    }
+    "Ingest Locations XML with XSD" should "produce file in accepted" in {
+      new SpecTrait(
+        domainOrJobFilename = "locations.comet.yml",
+        sourceDomainOrJobPathname = s"/sample/xsd/locations.comet.yml",
+        datasetDomainName = "locations",
+        sourceDatasetPathName = "/sample/xsd/locations.xml"
+      ) {
+        cleanMetadata
+        cleanDatasets
+
+        loadPending
+
+        readFileContent(
+          cometDatasetsPath + s"/${settings.comet.area.archive}/$datasetDomainName/locations.xml"
+        ) shouldBe loadTextFile(
+          sourceDatasetPathName
+        )
+
+        // Accepted should have the same data as input
+        val acceptedDf = sparkSession.read
+          .parquet(
+            cometDatasetsPath + s"/accepted/$datasetDomainName/locations/$getTodayPartitionPath"
+          )
+
+        import sparkSession.implicits._
+        val (seconds, millis) =
+          acceptedDf
+            .select($"seconds", $"millis")
+            .filter($"name" like "Paris")
+            .as[(String, String)]
+            .collect()
+            .head
+
+        // We just check against the year since the test may be executed in a different time zone :)
+        seconds.substring(0, 4) shouldBe "1631"
+        millis.substring(0, 4) shouldBe "1631"
       }
     }
     "Load Business with Transform Tag" should "load an AutoDesc" in {


### PR DESCRIPTION
## Summary
The objective here is to use the XSD provided by the user to do a validation.

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
Simply provide the psd using the xsdPath option and no need to fill the attributes section.
Starlake will atomically convert he XSD schema to the Yaml schema in memory and let the existing code do the validation.


This PR is a prelude to a second PR that will let the user to add extra configuration in the attributes section for specific fields such as policy tags or privacy options and also include scripted fields