### PR TITLE
ci: remove github registry support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Release notes
 
+# 0.3.27
+__CI__:
+ - remove support of github registry
+
 # 0.3.26
 __New feature__:
 - Support JINJA in autojob

--- a/build.sbt
+++ b/build.sbt
@@ -160,8 +160,6 @@ publishTo := {
     sys.env.getOrElse("RELEASE_SONATYPE", "true").toBoolean
   ) match {
     case (None, false) =>
-      // githubPublishTo.value
-      // we do not publish on github anymore
       sonatypePublishToBundle.value
     case (None, true) => sonatypePublishToBundle.value
     case (Some(value), _) =>
@@ -221,16 +219,6 @@ releaseProcess := Seq(
 releaseCommitMessage := s"Release ${ReleasePlugin.runtimeVersion.value}"
 
 releaseVersionBump := Next
-
-// publish to github packages
-// we do not publish on github anymore
-//githubOwner := "starlake-ai"
-
-// we do not publish on github anymore
-// githubRepository := "starlake"
-
-// we do not publish on github anymore
-// githubTokenSource := TokenSource.Environment("GITHUB_TOKEN")
 
 developers := List(
   Developer(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,5 +29,3 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
-
-addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")


### PR DESCRIPTION
## Summary
When building this application on a clean network, I've faced an issue with an unset GITHUB token and was unable to build the project.

**PR Type: CI**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
Remove sbt-github-packages plugin and all its commented config.

### How has this been tested?
This has been tested locally. Local build (sbt clean assembly) was a success without this plugin.
Test currently fails at: 
 ai.starlake.job.kafka.KafkaJobSpec
 ai.starlake.schema.handlers.SchemaHandlerSpec

but this doesn't seem to be related to github registry.

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have updated the Release notes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.



