### PR TITLE
fix: allow dataset rename on merge job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Release notes
 
+# 0.6.3
+__Bug Fix__:
+- allow bigquery job to work on a dataset of another project based on dataset name combined with projectId
+
 # 0.6.2
 __New Feature__:
 - Support BigQuery IAM Policy Tags 

--- a/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
@@ -1054,7 +1054,7 @@ trait IngestionJob extends SparkJob {
   ): (DataFrame, List[String]) = {
     // When merging to BigQuery, load existing DF from BigQuery
     val tableMetadata =
-      BigQuerySparkJob.getTable(session, domain.getFinalName(), schema.getFinalName())
+      BigQuerySparkJob.getTable(session, domain.getFinalName() + "." + schema.getFinalName())
     val existingDF = tableMetadata.table
       .map { table =>
         val incomingSchema = BigQueryUtils.normalizeSchema(schema.finalSparkSchema(schemaHandler))

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
@@ -157,7 +157,7 @@ class BigQueryNativeJob(
 
   def createTable(datasetName: String, tableName: String, schema: Schema): Unit = {
     Try {
-      val tableId = TableId.of(datasetName, tableName)
+      val tableId = extractProjectDatasetAndTable(datasetName, tableName)
       val table = scala.Option(bigquery().getTable(tableId))
       table match {
         case Some(tbl) if tbl.exists() =>
@@ -197,6 +197,9 @@ class BigQueryNativeJob(
       }
     }
   }
+
+  override def extractProjectDatasetAndTable(resourceId: String): TableId =
+    BigQueryJobBase.extractProjectDatasetAndTable(resourceId)
 }
 
 object BigQueryNativeJob extends StrictLogging {}

--- a/src/test/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJobSpec.scala
+++ b/src/test/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJobSpec.scala
@@ -1,0 +1,23 @@
+package ai.starlake.job.sink.bigquery
+
+import ai.starlake.TestHelper
+import com.google.cloud.bigquery.TableId
+
+class BigQuerySparkJobSpec extends TestHelper {
+  it should "get table with a dataset name including project" in {
+    val tableId = BigQuerySparkJob.getTableId(sparkSession, "my-project:my-dataset.my-table")
+    tableId shouldBe TableId.of("my-project", "my-dataset", "my-table")
+  }
+
+  it should "get table with default project id when dataset name doesn't include projectId" in {
+    val tableId = BigQuerySparkJob.getTableId(sparkSession, "my-dataset.my-table")
+    tableId.getDataset shouldBe "my-dataset"
+    tableId.getTable shouldBe "my-table"
+  }
+
+  it should "get table with default project id specified in spark conf when dataset name doesn't include projectId" in {
+    sparkSession.sparkContext.hadoopConfiguration.set("fs.gs.project.id", "my-project")
+    val tableId = BigQuerySparkJob.getTableId(sparkSession, "my-dataset.my-table")
+    tableId shouldBe TableId.of("my-project", "my-dataset", "my-table")
+  }
+}


### PR DESCRIPTION
## Summary
missing dataset name extraction to deduce projectId from it making jobs such as merge to fail when specifying it.

**Related Issue: #IssueId**
none

**PR Type: Bug Fix **

**Status: Ready to review**

**Breaking change? Yes/No**
No


## Description
### Solution
Extract projectId from dataset name first

### How has this been tested?
With unit tests and on our development environment

### Other changes
None

### Deploy Notes
None

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] I have updated the Release notes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.



