### PR TITLE
Add support for task refs and materialized views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 
 # 0.6.2
 __New Feature__:
-- Support BigQuery IAM Policy Tags 
+- Support BigQuery IAM Policy Tags
+- Support task refs in autojob file
+- Support materialized views in autojob
 
 - __ Breaking Changes__
   XLS and YML readers renamed. Breaking change if you are calling them outside the starlake command line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 # Release notes
 
 # 0.6.3
+- Support task refs in job definition files
+
+
+# 0.6.2
 __Bug Fix__:
 - allow bigquery job to work on a dataset of another project based on dataset name combined with projectId
 
-# 0.6.2
 __New Feature__:
 - Support BigQuery IAM Policy Tags
 - Support task refs in autojob file

--- a/docs/docs/cli/xls2yml.md
+++ b/docs/docs/cli/xls2yml.md
@@ -17,6 +17,7 @@ Parameter|Cardinality|Description
 ---|---|---
 --files:`<value>`|*Required*|List of Excel files describing Domains & Schemas
 --encryption:`<value>`|*Optional*|If true generate pre and post encryption YML
+--iamPolicyTagsFile:`<value>`|*Optional*|If true generate IAM PolicyTags YML
 --delimiter:`<value>`|*Optional*|CSV delimiter to use in post-encrypt YML.
 --privacy:`<value>`|*Optional*|What privacy policies should be applied in the pre-encryption phase ? All privacy policies are applied by default.
 --outputPath:`<value>`|*Optional*|Path for saving the resulting YAML file(s). Comet domains path is used by default.

--- a/docs/docs/cli/yml2xls.md
+++ b/docs/docs/cli/yml2xls.md
@@ -16,5 +16,6 @@ title: yml2xls
 Parameter|Cardinality|Description
 ---|---|---
 --domain:`<value>`|*Optional*|domains to convert to XLS
+--iamPolicyTagsFile:`<value>`|*Optional*|IAM PolicyTag file to convert to XLS, COMET_METADATA/iam-policy-tags.yml by default)
 --xls:`<value>`|*Required*|directory where XLS files are generated
 

--- a/src/main/scala/ai/starlake/job/Main.scala
+++ b/src/main/scala/ai/starlake/job/Main.scala
@@ -15,7 +15,7 @@ import ai.starlake.job.sink.kafka.KafkaJobConfig
 import ai.starlake.job.transform.{AutoTask2GraphVizConfig, AutoTaskToGraphViz}
 import ai.starlake.schema.generator._
 import ai.starlake.schema.handlers.{SchemaHandler, ValidateConfig}
-import ai.starlake.serve.{MainServer, MainServerConfig}
+import ai.starlake.serve.{SingleUserMainServer, MainServerConfig}
 import ai.starlake.utils.{CliConfig, CliEnvConfig, CometObjectMapper}
 import ai.starlake.workflow.{ImportConfig, IngestionWorkflow, TransformConfig, WatchConfig}
 import buildinfo.BuildInfo
@@ -345,7 +345,7 @@ class Main() extends StrictLogging {
       case "serve" =>
         MainServerConfig.parse(args.drop(1)) match {
           case Some(config) =>
-            MainServer.serve(config)
+            SingleUserMainServer.serve(config)
             true
           case _ =>
             println(MainServerConfig.usage())

--- a/src/main/scala/ai/starlake/job/Main.scala
+++ b/src/main/scala/ai/starlake/job/Main.scala
@@ -15,7 +15,7 @@ import ai.starlake.job.sink.kafka.KafkaJobConfig
 import ai.starlake.job.transform.{AutoTask2GraphVizConfig, AutoTaskToGraphViz}
 import ai.starlake.schema.generator._
 import ai.starlake.schema.handlers.{SchemaHandler, ValidateConfig}
-import ai.starlake.serve.{SingleUserMainServer, MainServerConfig}
+import ai.starlake.serve.{MainServerConfig, SingleUserMainServer}
 import ai.starlake.utils.{CliConfig, CliEnvConfig, CometObjectMapper}
 import ai.starlake.workflow.{ImportConfig, IngestionWorkflow, TransformConfig, WatchConfig}
 import buildinfo.BuildInfo

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryLoadConfig.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryLoadConfig.scala
@@ -28,7 +28,8 @@ case class BigQueryLoadConfig(
   partitionsToUpdate: List[String] = Nil,
   acl: List[AccessControlEntry] = Nil,
   starlakeSchema: Option[Schema] = None,
-  domainTags: Set[String] = Set.empty
+  domainTags: Set[String] = Set.empty,
+  materializedView: Boolean = false
 ) {
   def getLocation(): String = this.location.getOrElse("EU")
   def getCredentials()(implicit settings: Settings): Option[ServiceAccountCredentials] = {

--- a/src/main/scala/ai/starlake/job/transform/AutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/AutoTask.scala
@@ -63,8 +63,8 @@ object AutoTask extends StrictLogging {
     jobDesc.tasks.map(taskDesc =>
       AutoTask(
         jobDesc.name,
-        jobDesc.format,
-        jobDesc.coalesce.getOrElse(false),
+        taskDesc.format.orElse(jobDesc.format),
+        taskDesc.coalesce.orElse(jobDesc.coalesce).getOrElse(false),
         jobDesc.udf,
         Views(jobDesc.views.getOrElse(Map.empty)),
         jobDesc.getEngine(),
@@ -132,7 +132,10 @@ case class AutoTask(
       rls = taskDesc.rls,
       engine = Engine.BQ,
       options = bqSink.getOptions,
-      acl = taskDesc.acl
+      acl = taskDesc.acl,
+      materializedView = taskDesc.sink.exists(sink =>
+        sink.asInstanceOf[BigQuerySink].materializedView.getOrElse(false)
+      )
     )
   }
 

--- a/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
@@ -97,7 +97,7 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
 
   def fullValidation(config: ValidateConfig = ValidateConfig(reload = false)): Unit = {
     val validityErrorsAndWarnings = checkValidity(config.reload)
-    val deserErrors = deserializedDomains
+    val deserErrors = deserializedDomains()
       .filter { case (path, res) =>
         res.isFailure
       } map { case (path, err) =>
@@ -325,7 +325,7 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
     */
   def getType(tpe: String): Option[Type] = types().find(_.name == tpe)
 
-  def deserializedDomains: List[(Path, Try[Domain])] = {
+  def deserializedDomains(): List[(Path, Try[Domain])] = {
     val paths = storage.list(
       DatasetArea.domains,
       extension = ".yml",
@@ -355,20 +355,30 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
     */
   @throws[Exception]
   private def loadDomains(): (List[String], List[Domain]) = {
-    val (validDomainsFile, invalidDomainsFiles) = deserializedDomains
+    val (validDomainsFile, invalidDomainsFiles) = deserializedDomains()
       .map {
         case (path, Success(domain)) =>
           logger.info(s"Loading domain from $path")
           val folder = path.getParent()
-          val schemaRefs = domain.tableRefs
-            .map { ref =>
-              if (!ref.startsWith("_"))
-                throw new Exception(
-                  s"reference to a schema should start with '_' in domain ${domain.name} in $path for schema ref $ref"
-                )
-              val refFullName =
+          val tableRefNames = domain.tableRefs match {
+            case "*" :: Nil =>
+              storage
+                .list(folder, extension = ".yml", recursive = true)
+                .map(_.getName())
+                .filter(_.startsWith("_"))
+            case _ =>
+              domain.tableRefs.map { ref =>
+                if (!ref.startsWith("_"))
+                  throw new Exception(
+                    s"reference to a schema should start with '_' in domain ${domain.name} in $path for schema ref $ref"
+                  )
                 if (ref.endsWith(".yml") || ref.endsWith(".yaml")) ref else ref + ".comet.yml"
-              val schemaPath = new Path(folder, refFullName)
+              }
+          }
+
+          val schemaRefs = tableRefNames
+            .map { tableRefName =>
+              val schemaPath = new Path(folder, tableRefName)
               YamlSerializer.deserializeSchemas(
                 Utils
                   .parseJinja(storage.read(schemaPath), activeEnv())
@@ -442,9 +452,9 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
     undefinedVars.map(undefVar => s"""${path.getName} contains undefined var: ${undefVar}""")
   }
 
-  def loadJobFromFile(path: Path): Try[AutoJobDesc] =
+  def loadJobFromFile(jobPath: Path): Try[AutoJobDesc] =
     Try {
-      val fileContent = storage.read(path)
+      val fileContent = storage.read(jobPath)
       val rootContent =
         Utils.parseJinja(fileContent, activeEnv()).richFormat(activeEnv(), Map.empty)
 
@@ -453,7 +463,7 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
       val autojobNode =
         if (tranformNode.isNull() || tranformNode.isMissingNode) {
           logger.warn(
-            s"Defining a autojob outside a transform node is now deprecated. Please update definition $path"
+            s"Defining an autojob outside a transform node is now deprecated. Please update definition $jobPath"
           )
           rootNode
         } else
@@ -483,10 +493,17 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
       // for file job.comet.yml containing a single unnamed task, we search for job.sql
       // for file job.comet.yml containing multiple named tasks (say task1, task2), we search for job.task1.sql & job.task2.sql
       val jobDesc = mapper.treeToValue(autojobNode, classOf[AutoJobDesc])
-      val tasks = jobDesc.tasks.map { taskDesc =>
-        val taskFile: Option[Path] = taskSqlPath(path, taskDesc.name)
+      val folder = jobPath.getParent()
+      val autoTasksRefs = loadTaskRefs(jobPath, jobDesc, folder)
 
-        taskFile
+      logger.info(s"Successfully loaded job  in $jobPath")
+      val jobDescWithRefs: AutoJobDesc =
+        jobDesc.copy(tasks = Option(jobDesc.tasks).getOrElse(Nil) ::: autoTasksRefs)
+
+      val tasks = jobDescWithRefs.tasks.map { taskDesc =>
+        val taskSqlFile: Option[Path] = taskSqlPath(jobPath, taskDesc.name)
+
+        taskSqlFile
           .map { taskFile =>
             val sqlTask = SqlTaskExtractor(storage.read(taskFile))
             taskDesc.copy(
@@ -499,21 +516,49 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
           }
           .getOrElse(taskDesc)
       }
-      val jobName = finalDomainOrJobName(path, jobDesc.name)
+      val jobName = finalDomainOrJobName(jobPath, jobDesc.name)
       val tasksWithNoSQL = tasks.filter(_.sql.isEmpty)
       assert(
         tasksWithNoSQL.isEmpty,
-        "Task requires to define a query either through sql attribute or a sql side car file."
+        s"Tasks ${tasksWithNoSQL.map(_.name).mkString(",")} in job ${jobDesc.name} in path $jobPath need to define a query either through sql attribute or a sql file."
       )
       jobDesc.copy(
         name = jobName,
-        tasks = tasks
+        tasks = tasks,
+        taskRefs = Nil
       )
     } match {
       case Success(value) => Success(value)
       case Failure(exception) =>
-        Failure(new Exception(s"Invalid Job file: $path(${exception.getMessage})", exception))
+        Failure(new Exception(s"Invalid Job file: $jobPath(${exception.getMessage})", exception))
     }
+
+  private def loadTaskRefs(path: Path, jobDesc: AutoJobDesc, folder: Path): List[AutoTaskDesc] = {
+    val autoTasksRefNames = jobDesc.taskRefs match {
+      case "*" :: Nil =>
+        storage
+          .list(folder, extension = ".yml", recursive = true)
+          .map(_.getName())
+          .filter(_.startsWith("_"))
+      case _ =>
+        jobDesc.taskRefs.map { ref =>
+          if (!ref.startsWith("_"))
+            throw new Exception(
+              s"reference to a job should start with '_' in task $ref in $path for job ${jobDesc.name}"
+            )
+          if (ref.endsWith(".yml") || ref.endsWith(".yaml")) ref else ref + ".comet.yml"
+        }
+    }
+    val autoTasksRefs = autoTasksRefNames.map { autoTasksRefName =>
+      val taskPath = new Path(folder, autoTasksRefName)
+      YamlSerializer.deserializeTask(
+        Utils
+          .parseJinja(storage.read(taskPath), activeEnv())
+          .richFormat(activeEnv(), Map.empty)
+      )
+    }
+    autoTasksRefs
+  }
 
   private def taskSqlPath(path: Path, taskName: Option[String]): Option[Path] = {
     val sqlFilePrefix = path.toString.substring(0, path.toString.length - ".comet.yml".length)
@@ -578,7 +623,12 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
     */
   @throws[Exception]
   private def loadJobs(): (List[String], Map[String, AutoJobDesc]) = {
-    val jobs = storage.list(DatasetArea.jobs, ".yml", recursive = true)
+    val jobs = storage.list(
+      DatasetArea.jobs,
+      ".yml",
+      recursive = true,
+      exclude = Some(Pattern.compile("_.*"))
+    )
     val filenameErrors = Utils.duplicates(
       jobs.map(_.getName()),
       s"%s is defined %d times. A job can only be defined once."

--- a/src/main/scala/ai/starlake/schema/model/AutoJobDesc.scala
+++ b/src/main/scala/ai/starlake/schema/model/AutoJobDesc.scala
@@ -123,7 +123,8 @@ case class AutoJobDesc(
   coalesce: Option[Boolean],
   udf: Option[String] = None,
   views: Option[Map[String, String]] = None,
-  engine: Option[Engine] = None
+  engine: Option[Engine] = None,
+  schedule: Option[Map[String, String]] = None
 ) {
 
   def getEngine(): Engine = engine.getOrElse(Engine.SPARK)

--- a/src/main/scala/ai/starlake/schema/model/AutoJobDesc.scala
+++ b/src/main/scala/ai/starlake/schema/model/AutoJobDesc.scala
@@ -61,7 +61,9 @@ case class AutoTaskDesc(
   assertions: Map[String, String] = Map.empty,
   engine: Option[Engine] = None,
   acl: List[AccessControlEntry] = Nil,
-  comment: Option[String] = None
+  comment: Option[String] = None,
+  format: Option[String] = None,
+  coalesce: Option[Boolean] = None
 ) {
 
   def this() = this(
@@ -116,6 +118,7 @@ case class AutoTaskDesc(
 case class AutoJobDesc(
   name: String,
   tasks: List[AutoTaskDesc],
+  taskRefs: List[String] = Nil,
   format: Option[String],
   coalesce: Option[Boolean],
   udf: Option[String] = None,

--- a/src/main/scala/ai/starlake/schema/model/Sink.scala
+++ b/src/main/scala/ai/starlake/schema/model/Sink.scala
@@ -127,7 +127,8 @@ final case class BigQuerySink(
   clustering: Option[Seq[String]] = None,
   days: Option[Int] = None,
   requirePartitionFilter: Option[Boolean] = None,
-  options: Option[Map[String, String]] = None
+  options: Option[Map[String, String]] = None,
+  materializedView: Option[Boolean] = None
 ) extends Sink(SinkType.BQ.value)
 
 /** When the sink *type* field is set to ES, the options below should be provided. Elasticsearch

--- a/src/main/scala/ai/starlake/serve/SingleUserMainServer.scala
+++ b/src/main/scala/ai/starlake/serve/SingleUserMainServer.scala
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.sparkproject.jetty.server.Server
 import org.sparkproject.jetty.servlet.ServletHandler
 
-object MainServer {
+object SingleUserMainServer {
   val mapper: ObjectMapper = new ObjectMapper()
   mapper.registerModule(DefaultScalaModule)
   mapper
@@ -41,25 +41,25 @@ object MainServer {
       case "quit" | "exit" =>
         System.exit(0)
         "" // makes the compiler happy
-      case "version"   => MainServer.mapper.writeValueAsString(BuildInfo.version)
-      case "heartbeat" => MainServer.mapper.writeValueAsString("OK")
+      case "version"   => SingleUserMainServer.mapper.writeValueAsString(BuildInfo.version)
+      case "heartbeat" => SingleUserMainServer.mapper.writeValueAsString("OK")
       case "domains" =>
         val settings =
           SettingsManager.getUpdatedSettings(root, metadata, env, gcpProject)
-        MainServer.mapper.writeValueAsString(Services.domains()(settings))
+        SingleUserMainServer.mapper.writeValueAsString(Services.domains()(settings))
       case "jobs" =>
         val settings =
           SettingsManager.getUpdatedSettings(root, metadata, env, gcpProject)
-        MainServer.mapper.writeValueAsString(Services.jobs()(settings))
+        SingleUserMainServer.mapper.writeValueAsString(Services.jobs()(settings))
       case "types" =>
         val settings =
           SettingsManager.getUpdatedSettings(root, metadata, env, gcpProject)
-        MainServer.mapper.writeValueAsString(Services.types()(settings))
+        SingleUserMainServer.mapper.writeValueAsString(Services.types()(settings))
       case _ =>
         val settings =
           SettingsManager.getUpdatedSettings(root, metadata, env, gcpProject)
         core.run(args)(settings)
-        MainServer.mapper.writeValueAsString(
+        SingleUserMainServer.mapper.writeValueAsString(
           Response(settings.comet.rootServe.getOrElse("Should never happen"))
         )
     }

--- a/src/main/scala/ai/starlake/serve/api/RequestHandler.scala
+++ b/src/main/scala/ai/starlake/serve/api/RequestHandler.scala
@@ -1,6 +1,6 @@
 package ai.starlake.serve.api
 
-import ai.starlake.serve.MainServer
+import ai.starlake.serve.SingleUserMainServer
 import ai.starlake.utils.Utils
 import better.files.File
 
@@ -23,7 +23,7 @@ class RequestHandler extends HttpServlet {
     System.out.println(s"ENV=$env")
     System.out.println(s"GCP_PROJECT=$gcpProject")
     try {
-      val response = MainServer.run(root, metadata, params, env, gcpProject)
+      val response = SingleUserMainServer.run(root, metadata, params, env, gcpProject)
       resp.setStatus(HttpServletResponse.SC_OK)
       resp.getWriter.println(response)
       println(response)

--- a/src/main/scala/ai/starlake/utils/YamlSerializer.scala
+++ b/src/main/scala/ai/starlake/utils/YamlSerializer.scala
@@ -2,7 +2,14 @@ package ai.starlake.utils
 
 import ai.starlake.config.Settings
 import ai.starlake.extract.JDBCSchemas
-import ai.starlake.schema.model.{AutoJobDesc, Domain, IamPolicyTags, Schema => ModelSchema, Schemas}
+import ai.starlake.schema.model.{
+  AutoJobDesc,
+  AutoTaskDesc,
+  Domain,
+  IamPolicyTags,
+  Schema => ModelSchema,
+  Schemas
+}
 import better.files.File
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.{JsonSetter, Nulls}
@@ -25,6 +32,7 @@ object YamlSerializer extends LazyLogging {
   def serialize(domain: Domain): String = mapper.writeValueAsString(domain)
 
   def serialize(iamPolicyTags: IamPolicyTags): String = mapper.writeValueAsString(iamPolicyTags)
+
   def deserializeIamPolicyTags(content: String): IamPolicyTags = {
     val rootNode = mapper.readTree(content)
     mapper.treeToValue(rootNode, classOf[IamPolicyTags])
@@ -41,6 +49,11 @@ object YamlSerializer extends LazyLogging {
     val jsonContent = jobWriter.writeValueAsString(job)
     // val jobReader = mapper.reader().withAttribute(classOf[Settings], settings)
     mapper.readValue(jsonContent, classOf[Map[String, Any]])
+  }
+
+  def deserializeTask(content: String): AutoTaskDesc = {
+    val rootNode = mapper.readTree(content)
+    mapper.treeToValue(rootNode, classOf[AutoTaskDesc])
   }
 
   def serialize(jdbcSchemas: JDBCSchemas): String = mapper.writeValueAsString(jdbcSchemas)

--- a/src/main/scala/ai/starlake/utils/YamlSerializer.scala
+++ b/src/main/scala/ai/starlake/utils/YamlSerializer.scala
@@ -53,7 +53,13 @@ object YamlSerializer extends LazyLogging {
 
   def deserializeTask(content: String): AutoTaskDesc = {
     val rootNode = mapper.readTree(content)
-    mapper.treeToValue(rootNode, classOf[AutoTaskDesc])
+    val taskNode = rootNode.path("task")
+    val targetNode =
+      if (taskNode.isNull() || taskNode.isMissingNode) {
+        rootNode.asInstanceOf[ObjectNode]
+      } else
+        taskNode.asInstanceOf[ObjectNode]
+    mapper.treeToValue(targetNode, classOf[AutoTaskDesc])
   }
 
   def serialize(jdbcSchemas: JDBCSchemas): String = mapper.writeValueAsString(jdbcSchemas)

--- a/src/test/resources/sample/job-with-taskrefs/_task1.comet.yml
+++ b/src/test/resources/sample/job-with-taskrefs/_task1.comet.yml
@@ -1,0 +1,8 @@
+sql: "select * from table1"
+name: task1
+domain: "myjob"
+table: "table1"
+write: "OVERWRITE"
+partition:
+  - "year"
+  - "month"

--- a/src/test/resources/sample/job-with-taskrefs/_task2.comet.yml
+++ b/src/test/resources/sample/job-with-taskrefs/_task2.comet.yml
@@ -1,0 +1,5 @@
+task:
+  sql: "select * from table2"
+  domain: "myjob"
+  table: "table2"
+  write: "OVERWRITE"

--- a/src/test/resources/sample/job-with-taskrefs/my-job.comet.yml
+++ b/src/test/resources/sample/job-with-taskrefs/my-job.comet.yml
@@ -1,0 +1,14 @@
+---
+transform:
+  name: "my-job"
+  taskRefs:
+    - _task1
+    - _task2.comet.yml
+  tasks:
+    - sql: "select * from dream_working.client"
+      domain: "dream2"
+      table: "client2"
+      write: "OVERWRITE"
+      partition:
+        - "year"
+        - "month"

--- a/src/test/resources/sample/schema-refs/WITH_REF.comet.yml
+++ b/src/test/resources/sample/schema-refs/WITH_REF.comet.yml
@@ -17,10 +17,10 @@ load:
         - comet_day
     sink:
       type: ES
-  schemaRefs:
+  tableRefs:
     - _users.comet.yml
     - _players
-  schemas:
+  tables:
     - name: "employee"
       pattern: "employee.*.csv"
       attributes:

--- a/src/test/scala/ai/starlake/job/connections/ConnectionJobsSpec.scala
+++ b/src/test/scala/ai/starlake/job/connections/ConnectionJobsSpec.scala
@@ -35,6 +35,7 @@ class ConnectionJobsSpec extends TestHelper {
         AutoJobDesc(
           "user",
           List(businessTask1),
+          Nil,
           Some("parquet"),
           Some(false),
           views = Some(Map("user_View" -> s"jdbc:$connection:select * from users"))

--- a/src/test/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJobSpec.scala
+++ b/src/test/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJobSpec.scala
@@ -101,6 +101,7 @@ class BigQueryNativeJobSpec extends TestHelper with BeforeAndAfterAll {
             AutoJobDesc(
               "bqjobtest",
               List(businessTask1),
+              Nil,
               None,
               None,
               None,

--- a/src/test/scala/ai/starlake/schema/generator/YamlSerializerSpec.scala
+++ b/src/test/scala/ai/starlake/schema/generator/YamlSerializerSpec.scala
@@ -18,6 +18,7 @@ class YamlSerializerSpec extends TestHelper {
         AutoJobDesc(
           "user",
           List(task),
+          Nil,
           Some("parquet"),
           Some(false),
           views = Some(Map("user_View" -> "accepted/user"))

--- a/src/test/scala/ai/starlake/schema/handlers/AutoJobHandlerSpec.scala
+++ b/src/test/scala/ai/starlake/schema/handlers/AutoJobHandlerSpec.scala
@@ -60,6 +60,7 @@ class AutoJobHandlerSpec extends TestHelper with BeforeAndAfterAll {
         AutoJobDesc(
           "user",
           List(businessTask1),
+          Nil,
           Some("parquet"),
           Some(false),
           views = Some(Map("user_View" -> "accepted/user"))
@@ -110,6 +111,7 @@ class AutoJobHandlerSpec extends TestHelper with BeforeAndAfterAll {
         AutoJobDesc(
           "user",
           List(businessTask1),
+          Nil,
           Some("parquet"),
           Some(false),
           views = Some(Map("user_View" -> "accepted/user"))
@@ -144,6 +146,7 @@ class AutoJobHandlerSpec extends TestHelper with BeforeAndAfterAll {
         AutoJobDesc(
           "user",
           List(businessTask1),
+          Nil,
           Some("parquet"),
           Some(false),
           views = Some(Map("user_View" -> "accepted/user"))
@@ -192,6 +195,7 @@ class AutoJobHandlerSpec extends TestHelper with BeforeAndAfterAll {
         AutoJobDesc(
           "user",
           List(businessTask1),
+          Nil,
           Some("parquet"),
           Some(false),
           views = Some(Map("user_View" -> "accepted/user"))
@@ -235,6 +239,7 @@ class AutoJobHandlerSpec extends TestHelper with BeforeAndAfterAll {
         AutoJobDesc(
           "user",
           List(businessTask1),
+          Nil,
           Some("parquet"),
           Some(false),
           udf = Some("ai.starlake.udf.TestUdf"),
@@ -287,6 +292,7 @@ class AutoJobHandlerSpec extends TestHelper with BeforeAndAfterAll {
         AutoJobDesc(
           "graduateProgram",
           List(businessTask1),
+          Nil,
           Some("parquet"),
           Some(false),
           views = Some(Map("graduate_View" -> "accepted/graduateProgram"))

--- a/src/test/scala/ai/starlake/schema/handlers/StorageHandlerSpec.scala
+++ b/src/test/scala/ai/starlake/schema/handlers/StorageHandlerSpec.scala
@@ -161,6 +161,7 @@ class StorageHandlerSpec extends TestHelper {
         AutoJobDesc(
           "business1",
           List(businessTask1),
+          Nil,
           Some("parquet"),
           Some(true)
         )


### PR DESCRIPTION
## Summary
We now allow jobs to create materialised views. enableRefresh and refreshIntervalMs have been added to BigQuerySink

Additionally, tasks may be defined in their own files and referenced in the job file using the taskRefs attribute as follows:

```
taskRefs:
  - *

or else

taskRefs:
  - _taskName1.comet.yml
  - _taskName2.comet.yml
```
 
**PR Type: Feature**

**Status: WIP**

**Breaking change? No**

