### PR TITLE
fix: restore the ability to override intermediate bq format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ __New Feature__:
 
 __Bug Fix__:
 - Upsert table description for nested fields
+- Restore the ability to override intermediate bq format
 
 # 0.6.3
 __New Feature__:

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -213,7 +213,7 @@ internal {
   # For orc format (All fields in the detected schema are NULLABLE) : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-orc
   # For avro format : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro
   intermediate-bigquery-format = "parquet"
-  intersumediate-bigquery-format = ${?COMET_INTERMEDIATE_BQ_FORMAT}
+  intermediate-bigquery-format = ${?COMET_INTERMEDIATE_BQ_FORMAT}
   substitute-vars = true
   substitute-vars = ${?COMET_INTERNAL_SUBSTITUTE_VARS}
   temporary-gcs-bucket = ${?TEMPORARY_GCS_BUCKET}


### PR DESCRIPTION
fix typo otherwise we are not able to override the intermediate bq format via environment variable.