### PR TITLE
bugfix for BQ merge and file sink 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ __New Feature__:
 __Bug Fix__:
 - Upsert table description for nested fields
 - Restore the ability to override intermediate bq format
-- Exclude specific BQ partitions when apply Merge with a BQ Table
+- Exclude specific BQ partitions when applying Merge with a BQ Table
 - Apply spark options defined in the job description (sink) when saving into file 
 
 # 0.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ __New Feature__:
 __Bug Fix__:
 - Upsert table description for nested fields
 - Restore the ability to override intermediate bq format
+- Exclude specific BQ partitions when apply Merge with a BQ Table
+- Apply spark options defined in the job description (sink) when saving into file 
 
 # 0.6.3
 __New Feature__:

--- a/src/main/scala/ai/starlake/job/transform/AutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/AutoTask.scala
@@ -421,8 +421,17 @@ case class AutoTask(
               .load()
         }
 
-      if (settings.comet.hive || settings.comet.sinkToFile)
-        sinkToFS(dataframe, FsSink())
+      if (settings.comet.hive || settings.comet.sinkToFile) {
+        val fsSink = sink match {
+          case Some(sink) =>
+            sink match {
+              case fsSink: FsSink => fsSink
+              case _              => FsSink()
+            }
+          case _ => FsSink()
+        }
+        sinkToFS(dataframe, fsSink)
+      }
 
       if (settings.comet.assertions.active) {
         new AssertionJob(

--- a/src/main/scala/ai/starlake/schema/model/MergeOptions.scala
+++ b/src/main/scala/ai/starlake/schema/model/MergeOptions.scala
@@ -64,13 +64,14 @@ case class MergeOptions(
   )(implicit
     settings: Settings
   ): Option[String] = {
+    val filteredPartitions = partitions.filter(!_.startsWith("__"))
     (queryFilterContainsLast, queryFilterContainsLatest) match {
-      case (true, false)  => buildBQQueryForLast(partitions, activeEnv, options)
-      case (false, true)  => buildBQQueryForLastest(partitions, activeEnv, options)
+      case (true, false)  => buildBQQueryForLast(filteredPartitions, activeEnv, options)
+      case (false, true)  => buildBQQueryForLastest(filteredPartitions, activeEnv, options)
       case (false, false) => formatQuery(activeEnv, options)
       case (true, true) =>
-        val last = buildBQQueryForLast(partitions, activeEnv, options)
-        this.copy(queryFilter = last).buildBQQueryForLastest(partitions, activeEnv, options)
+        val last = buildBQQueryForLast(filteredPartitions, activeEnv, options)
+        this.copy(queryFilter = last).buildBQQueryForLastest(filteredPartitions, activeEnv, options)
     }
   }
 

--- a/src/main/scala/ai/starlake/schema/model/Sink.scala
+++ b/src/main/scala/ai/starlake/schema/model/Sink.scala
@@ -157,11 +157,11 @@ final case class NoneSink(
 @JsonTypeName("FS")
 final case class FsSink(
   override val name: Option[String] = None,
-  override val options: Option[Map[String, String]] = None,
   format: Option[String] = None,
   extension: Option[String] = None,
   clustering: Option[Seq[String]] = None,
-  partition: Option[Partition] = None
+  partition: Option[Partition] = None,
+  options: Option[Map[String, String]] = None
 ) extends Sink(SinkType.FS.value)
 
 /** When the sink *type* field is set to JDBC, the options below should be provided.

--- a/src/test/resources/sample/job/csvOutputJob.comet.yml
+++ b/src/test/resources/sample/job/csvOutputJob.comet.yml
@@ -1,0 +1,17 @@
+transform:
+  coalesce: true
+  format: csv
+  tasks:
+    - name: csvOutput
+      domain: result
+      table: file
+      write: OVERWRITE
+      sql: |
+        select '  Name' as name,'Last Name   ' as lastName, '' as emptColumn
+      sink:
+        type: "FS"
+        options:
+          emptyValue: ""
+          delimiter: "|"
+          ignoreLeadingWhiteSpace: false
+          ignoreTrailingWhiteSpace: false

--- a/src/test/scala/ai/starlake/job/transform/AutoTaskSpec.scala
+++ b/src/test/scala/ai/starlake/job/transform/AutoTaskSpec.scala
@@ -7,7 +7,7 @@ import org.apache.hadoop.fs.Path
 
 class AutoTaskSpec extends TestHelper {
   new WithSettings() {
-    "Load Transform Job with taskrefs" should "succeed" in {
+    "File Sink Spark Options in job description " should "be applied to resulting file" in {
       new SpecTrait(
         domainOrJobFilename = "csvOutputJob.comet.yml",
         sourceDomainOrJobPathname = "/sample/job/csvOutputJob.comet.yml",

--- a/src/test/scala/ai/starlake/job/transform/AutoTaskSpec.scala
+++ b/src/test/scala/ai/starlake/job/transform/AutoTaskSpec.scala
@@ -1,0 +1,30 @@
+package ai.starlake.job.transform
+
+import ai.starlake.TestHelper
+import ai.starlake.schema.handlers.{SchemaHandler, SimpleLauncher}
+import ai.starlake.workflow.IngestionWorkflow
+import org.apache.hadoop.fs.Path
+
+class AutoTaskSpec extends TestHelper {
+  new WithSettings() {
+    "Load Transform Job with taskrefs" should "succeed" in {
+      new SpecTrait(
+        domainOrJobFilename = "csvOutputJob.comet.yml",
+        sourceDomainOrJobPathname = "/sample/job/csvOutputJob.comet.yml",
+        datasetDomainName = "file",
+        sourceDatasetPathName = "",
+        isDomain = false
+      ) {
+        cleanMetadata
+        cleanDatasets
+        val schemaHandler = new SchemaHandler(settings.storageHandler)
+        val workflow = new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher)
+        workflow.autoJob(TransformConfig(name = "csvOutputJob"))
+
+        readFileContent(
+          new Path(cometDatasetsPath + "/result/file/file.csv")
+        ) shouldBe "  Name|Last Name   |"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Bug Fix for the following problems 
- When merging with a BigQuery tables the specific partitions such as __NULL__ and __UNPARTITIONED__ should be filtered
- When a job sinks to a csv file, spark options defined in the yaml file should be applied 

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**

## Description

### How has this been tested?
Unit Tests 

## Contributor checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the Release notes.


