### PR TITLE
Feature/freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ __New Feature__:
 - Import existing BigQuery Datasets and Tables
 - Generate Dataset and Table statistics
 - upsert table description
+- Support freshness in command line mode (getting ready for dependency mode)
+- Extract BigQuery Tables infos to dataset_info and table_info tables
+- Import BigQuery Project into external metadata folder
 
 __Bug Fix__:
 - Upsert table description for nested fields

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -20,7 +20,7 @@ object Versions {
   val bigquery = "2.23.0"
   val hadoop = "3.3.4"
   val sparkBigqueryWithDependencies = "0.28.0"
-  val sparkBigqueryConnectorCommon = "0.30.1"
+  val sparkBigqueryConnectorCommon = "0.28.0"
   val bigqueryConnector = "hadoop3-1.2.0"
   val h2 = "2.1.214" // Test only
   val poi = "4.1.2"

--- a/src/main/scala/ai/starlake/extract/BigQueryFreshnessConfig.scala
+++ b/src/main/scala/ai/starlake/extract/BigQueryFreshnessConfig.scala
@@ -1,0 +1,54 @@
+package ai.starlake.extract
+
+import ai.starlake.config.GcpConnectionConfig
+import ai.starlake.utils.CliConfig
+import scopt.OParser
+
+case class BigQueryFreshnessConfig(
+  gcpProjectId: Option[String] = None,
+  gcpSAJsonKey: Option[String] = None,
+  location: Option[String] = None,
+  tables: Map[String, List[String]] = Map.empty,
+  jobs: Seq[String] = Seq.empty
+) extends GcpConnectionConfig
+
+object BigQueryFreshnessConfig extends CliConfig[BigQueryFreshnessConfig] {
+  val command = "bq-freshness"
+  val parser: OParser[Unit, BigQueryFreshnessConfig] = {
+    val builder = OParser.builder[BigQueryFreshnessConfig]
+    import builder._
+    OParser.sequence(
+      programName(s"starlake $command"),
+      head("starlake", command, "[options]"),
+      note(""),
+      opt[String]("gcpProjectId")
+        .action { (x, c) => c.copy(gcpProjectId = Some(x)) }
+        .optional()
+        .text("gcpProjectId"),
+      opt[String]("gcpSAJsonKey")
+        .action { (x, c) => c.copy(gcpSAJsonKey = Some(x)) }
+        .optional()
+        .text("gcpSAJsonKey"),
+      opt[String]("location")
+        .action { (x, c) => c.copy(location = Some(x)) }
+        .optional()
+        .text("location"),
+      opt[Seq[String]]("tables")
+        .action { (x, c) =>
+          val tables = x.map(_.split(".")).map(tab => tab(0) -> tab(1)).groupBy(_._1).map {
+            case (k, v) => (k, v.map(_._2))
+          }
+          c.copy(tables = tables.mapValues(_.toList))
+        }
+        .optional()
+        .text("List of datasetName.tableName1,datasetName.tableName2 ..."),
+      opt[Seq[String]]("jobs")
+        .action { (x, c) => c.copy(jobs = x) }
+        .optional()
+        .text("List of job names")
+    )
+  }
+
+  def parse(args: Seq[String]): Option[BigQueryFreshnessConfig] =
+    OParser.parse(parser, args, BigQueryFreshnessConfig())
+}

--- a/src/main/scala/ai/starlake/extract/BigQueryFreshnessInfo.scala
+++ b/src/main/scala/ai/starlake/extract/BigQueryFreshnessInfo.scala
@@ -1,0 +1,147 @@
+package ai.starlake.extract
+
+import ai.starlake.config.Settings
+import ai.starlake.schema.handlers.SchemaHandler
+import com.google.cloud.bigquery.{Dataset, Table}
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.duration.Duration
+
+case class FreshnessStatus(
+  domain: String,
+  table: String,
+  lastModifiedTime: Long,
+  currentTime: Long,
+  duration: Long,
+  warnOrError: String
+)
+
+object BigQueryFreshnessInfo {
+  def freshness(config: BigQueryFreshnessConfig)(implicit
+    settings: Settings
+  ): List[FreshnessStatus] = {
+    val tables: List[(Dataset, List[Table])] =
+      BigQueryTableInfo.extractTableInfos(config.gcpProjectId, config.tables)
+    import settings.storageHandler
+    val schemaHandler = new SchemaHandler(storageHandler)
+    val domains = schemaHandler.domains()
+    val tablesFreshnessStatuses = tables.flatMap { case (dsInfo, tableInfos) =>
+      val domain = domains.find(_.getFinalName().equalsIgnoreCase(dsInfo.getDatasetId.getDataset))
+      domain match {
+        case None => Nil
+        case Some(domain) =>
+          tableInfos.flatMap { tableInfo =>
+            val tableName = tableInfo.getTableId.getTable
+            val table = domain.tables.find(_.getFinalName().equalsIgnoreCase(tableName))
+            table match {
+              case None => Nil
+              case Some(table) =>
+                val freshness = table.metadata.flatMap(_.freshness)
+                freshness match {
+                  case None => Nil
+                  case Some(freshness) =>
+                    val warnStatus =
+                      getFreshnessStatus(
+                        domain.getFinalName(),
+                        tableInfo,
+                        table.getFinalName(),
+                        freshness.warn,
+                        "WARN",
+                        "TABLE"
+                      )
+                    val errorStatus =
+                      getFreshnessStatus(
+                        domain.getFinalName(),
+                        tableInfo,
+                        table.getFinalName(),
+                        freshness.error,
+                        "ERROR",
+                        "TABLE"
+                      )
+                    List(warnStatus, errorStatus).flatten
+                }
+            }
+          }
+      }
+    }
+    val jobs = schemaHandler.jobs()
+    val jobsFreshnessStatuses = tables.flatMap { case (dsInfo, tableInfos) =>
+      val tasks = jobs.flatMap(_._2.tasks)
+      val task = tasks
+        .find(_.domain.equalsIgnoreCase(dsInfo.getDatasetId.getDataset))
+      task match {
+        case None => Nil
+        case Some(task) =>
+          val tableInfo = tableInfos.find(_.getTableId.getTable.equalsIgnoreCase(task.name))
+          tableInfo match {
+            case None => Nil
+            case Some(tableInfo) =>
+              val freshness = task.freshness
+              freshness match {
+                case None => Nil
+                case Some(freshness) =>
+                  val warnStatus =
+                    getFreshnessStatus(
+                      task.domain,
+                      tableInfo,
+                      task.name,
+                      freshness.warn,
+                      "WARN",
+                      "JOB"
+                    )
+                  val errorStatus =
+                    getFreshnessStatus(
+                      task.domain,
+                      tableInfo,
+                      task.name,
+                      freshness.error,
+                      "ERROR",
+                      "JOB"
+                    )
+                  List(warnStatus, errorStatus).flatten
+              }
+          }
+      }
+    }
+    tablesFreshnessStatuses ++ jobsFreshnessStatuses
+  }
+
+  private def getFreshnessStatus(
+    domainName: String,
+    tableInfo: Table,
+    tableName: String,
+    duration: Option[String],
+    level: String,
+    typ: String
+  ): Option[FreshnessStatus] = {
+    duration match {
+      case None => None
+      case Some(duration) =>
+        val warnOrErrorDuration = Duration(duration).toMillis
+        val now = System.currentTimeMillis()
+        val lastModifiedTime = tableInfo.getLastModifiedTime
+        if (now - warnOrErrorDuration > lastModifiedTime)
+          Some(
+            FreshnessStatus(
+              domainName,
+              tableName,
+              lastModifiedTime,
+              now,
+              warnOrErrorDuration,
+              level
+            )
+          )
+        else
+          None
+    }
+  }
+
+  def run(args: Array[String]): List[FreshnessStatus] = {
+    implicit val settings: Settings = Settings(ConfigFactory.load())
+    val config =
+      BigQueryFreshnessConfig
+        .parse(args)
+        .getOrElse(throw new Exception("Could not parse arguments"))
+    freshness(config)
+  }
+}

--- a/src/main/scala/ai/starlake/extract/BigQueryFreshnessInfo.scala
+++ b/src/main/scala/ai/starlake/extract/BigQueryFreshnessInfo.scala
@@ -36,7 +36,8 @@ object BigQueryFreshnessInfo {
             table match {
               case None => Nil
               case Some(table) =>
-                val freshness = table.metadata.flatMap(_.freshness)
+                val freshness =
+                  table.metadata.flatMap(_.freshness).orElse(domain.metadata.flatMap(_.freshness))
                 freshness match {
                   case None => Nil
                   case Some(freshness) =>

--- a/src/main/scala/ai/starlake/extract/BigQueryProjectInfo.scala
+++ b/src/main/scala/ai/starlake/extract/BigQueryProjectInfo.scala
@@ -1,8 +1,7 @@
 package ai.starlake.extract
 
 import ai.starlake.config.{GcpConnectionConfig, Settings}
-import ai.starlake.schema.model.Domain
-import com.google.cloud.bigquery.{BigQuery, Dataset, Table}
+import com.google.cloud.bigquery.{Dataset, Table}
 
 import scala.jdk.CollectionConverters.iterableAsScalaIterableConverter
 
@@ -13,7 +12,7 @@ case class BigQueryConnectionConfig(
 ) extends GcpConnectionConfig
 
 object BigQueryInfo {
-  def extractProjectInfo(
+  def extractInfo(
     project: Option[String] = None
   )(implicit settings: Settings): List[(Dataset, List[Table])] = {
     val config = BigQueryConnectionConfig(project)
@@ -33,28 +32,5 @@ object BigQueryInfo {
         (bqDataset, bqTables.toList)
       }
       .toList
-  }
-
-  def extractDomainsInfo(
-    domains: List[Domain]
-  )(implicit settings: Settings): List[(Dataset, List[Table])] = {
-    domains.map { domain =>
-      val project = domain.project
-      val config = BigQueryConnectionConfig(project)
-      val bigquery = config.bigquery()
-      extractDomainInfo(domain, bigquery)
-    }
-  }
-
-  def extractDomainInfo(domain: Domain, bigquery: BigQuery): (Dataset, List[Table]) = {
-    val bqDataset: Dataset = bigquery.getDataset(domain.getFinalName())
-    val bqTables = domain.tables.map { table =>
-      extractTableInfo(domain.getFinalName(), table.getFinalName(), bigquery)
-    }
-    (bqDataset, bqTables)
-  }
-
-  def extractTableInfo(domainName: String, tableName: String, bigquery: BigQuery) = {
-    bigquery.getTable(domainName, tableName)
   }
 }

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJob.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJob.scala
@@ -192,7 +192,6 @@ class BigQuerySparkJob(
                 SaveMode.Append,
                 connectorOptions
               )
-
           }
 
           val finalDF = sourceDF.write
@@ -201,7 +200,6 @@ class BigQuerySparkJob(
             .option("table", bqTable)
             .option("intermediateFormat", intermediateFormat)
             .options(withFieldRelaxationOptions)
-
           finalDF.save()
       }
 

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQuerySparkWriter.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQuerySparkWriter.scala
@@ -1,0 +1,59 @@
+package ai.starlake.job.sink.bigquery
+
+import ai.starlake.config.Settings
+import ai.starlake.schema.model.{BigQuerySink, EsSink, FsSink, NoneSink, WriteMode}
+import ai.starlake.utils.Utils
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.spark.sql.DataFrame
+
+object BigQuerySparkWriter extends StrictLogging {
+  def sink(
+    authInfo: Map[String, String],
+    df: DataFrame,
+    tableName: String,
+    maybeTableDescription: Option[String],
+    writeMode: WriteMode
+  )(implicit
+    settings: Settings
+  ): Any = {
+    settings.comet.tableInfo.sink match {
+      case sink: BigQuerySink =>
+        val source = Right(Utils.setNullableStateOfColumn(df, nullable = true))
+        val (createDisposition, writeDisposition) = {
+          Utils.getDBDisposition(writeMode, hasMergeKeyDefined = false)
+        }
+        val bqLoadConfig =
+          BigQueryLoadConfig(
+            authInfo.get("gcpProjectId"),
+            authInfo.get("gcpSAJsonKey"),
+            source = source,
+            outputTable = tableName,
+            outputDataset = sink.name.getOrElse("audit"),
+            sourceFormat = settings.comet.defaultFormat,
+            createDisposition = createDisposition,
+            writeDisposition = writeDisposition,
+            location = sink.location,
+            outputPartition = sink.timestamp,
+            outputClustering = sink.clustering.getOrElse(Nil),
+            days = sink.days,
+            requirePartitionFilter = sink.requirePartitionFilter.getOrElse(false),
+            rls = Nil,
+            options = sink.getOptions,
+            acl = Nil
+          )
+        val result = new BigQuerySparkJob(
+          bqLoadConfig,
+          maybeSchema = None,
+          maybeTableDescription = maybeTableDescription
+        ).run()
+        Utils.logFailure(result, logger)
+        result.isSuccess
+      case _: EsSink =>
+        // TODO Sink Audit Log to ES
+        throw new Exception("Sinking Audit log to Elasticsearch not yet supported")
+      case _: NoneSink | FsSink(_, _, _, _, _, _) =>
+      // Do nothing dataset already sinked to file. Forced at the reference.conf level
+      case _ =>
+    }
+  }
+}

--- a/src/main/scala/ai/starlake/schema/generator/BigQuery2YmlConfig.scala
+++ b/src/main/scala/ai/starlake/schema/generator/BigQuery2YmlConfig.scala
@@ -14,7 +14,7 @@ case class BigQueryTablesConfig(
 ) extends GcpConnectionConfig
 
 object BigQueryTablesConfig extends CliConfig[BigQueryTablesConfig] {
-  val command = "bq2yml or b2-log"
+  val command = "bq2yml or bq-info"
 
   val parser: OParser[Unit, BigQueryTablesConfig] = {
     val builder = OParser.builder[BigQueryTablesConfig]
@@ -38,7 +38,7 @@ object BigQueryTablesConfig extends CliConfig[BigQueryTablesConfig] {
       opt[String]("location")
         .action { (x, c) => c.copy(location = Some(x)) }
         .optional()
-        .text("tables"),
+        .text("location"),
       opt[Seq[String]]("tables")
         .action { (x, c) =>
           val tables = x.map(_.split(".")).map(tab => tab(0) -> tab(1)).groupBy(_._1).map {

--- a/src/main/scala/ai/starlake/schema/model/AutoJobDesc.scala
+++ b/src/main/scala/ai/starlake/schema/model/AutoJobDesc.scala
@@ -64,11 +64,13 @@ case class AutoTaskDesc(
   acl: List[AccessControlEntry] = Nil,
   comment: Option[String] = None,
   format: Option[String] = None,
-  coalesce: Option[Boolean] = None
+  coalesce: Option[Boolean] = None,
+  freshness: Option[Freshness] = None
 ) extends Named {
 
-  // TODO
-  def checkValidity() = true
+  def checkValidity(): Either[List[String], Boolean] = {
+    freshness.map(_.checkValidity()).getOrElse(Right(true))
+  }
 
   def this() = this(
     "",

--- a/src/main/scala/ai/starlake/schema/model/Freshness.scala
+++ b/src/main/scala/ai/starlake/schema/model/Freshness.scala
@@ -1,0 +1,37 @@
+package ai.starlake.schema.model
+
+import scala.collection.mutable
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success, Try}
+
+case class Freshness(
+  partitionFilter: Option[String] = None,
+  timestamp: Option[String] = None,
+  warn: Option[String] = None,
+  error: Option[String] = None
+) {
+  def checkValidity(): Either[List[String], Boolean] = {
+    val errorList: mutable.MutableList[String] = mutable.MutableList.empty
+
+    def checkDuration(duration: Option[String]): Unit = {
+      Try {
+        duration.map(Duration(_).toSeconds)
+      } match {
+        case Failure(_) => errorList += s"$duration could not be parsed as a duration"
+        case Success(_) =>
+      }
+    }
+
+    checkDuration(warn)
+    checkDuration(error)
+    timestamp match {
+      case Some(_) if warn.isEmpty && error.isEmpty =>
+        errorList += "When freshness timestamp is present, warn and/or error duration should be defined"
+      case _ =>
+    }
+    if (errorList.isEmpty)
+      Right(true)
+    else
+      Left(errorList.toList)
+  }
+}

--- a/src/test/resources/sample/position/bqtest.comet.yml
+++ b/src/test/resources/sample/position/bqtest.comet.yml
@@ -42,6 +42,10 @@ load:
           sampling: 0
           attributes: []
     - name: "account"
+      metadata:
+        freshness:
+          warn: "1 ms"
+          error: "2 ms"
       tags: ["tablekey=value", "tablekeynovalue"]
       rls:
         - name: "bqrls"

--- a/src/test/scala/ai/starlake/job/infer/InferSchemaSpec.scala
+++ b/src/test/scala/ai/starlake/job/infer/InferSchemaSpec.scala
@@ -14,8 +14,8 @@ class InferSchemaSpec extends TestHelper {
           |  --table <value>        Table Name
           |  --input <value>        Dataset Input Path
           |  --output-dir <value>   Domain YAML Output Path
+          |  --format <value>       Force format
           |  --with-header          Does the file contain a header (For CSV files only)
-          |  --format <value>       Forceformat
           |""".stripMargin
       rendered.substring(rendered.indexOf("Usage:")).replaceAll("\\s", "") shouldEqual expected
         .replaceAll("\\s", "")

--- a/src/test/scala/ai/starlake/job/infer/InferSchemaSpec.scala
+++ b/src/test/scala/ai/starlake/job/infer/InferSchemaSpec.scala
@@ -15,6 +15,7 @@ class InferSchemaSpec extends TestHelper {
           |  --input <value>        Dataset Input Path
           |  --output-dir <value>   Domain YAML Output Path
           |  --with-header          Does the file contain a header (For CSV files only)
+          |  --format <value>       Forceformat
           |""".stripMargin
       rendered.substring(rendered.indexOf("Usage:")).replaceAll("\\s", "") shouldEqual expected
         .replaceAll("\\s", "")

--- a/src/test/scala/ai/starlake/schema/handlers/InferSchemaJobSpec.scala
+++ b/src/test/scala/ai/starlake/schema/handlers/InferSchemaJobSpec.scala
@@ -98,7 +98,8 @@ class InferSchemaJobSpec extends TestHelper {
             "flat_locations",
             sourceFile.pathAsString,
             targetDir.pathAsString,
-            true
+            true,
+            None
           )
           val targetFile = File(targetDir, "locations.comet.yml")
           val maybeDomain =


### PR DESCRIPTION
## Summary
Support freshness control on tables and job but without dependency checking
Freshness is defined as follows on tables metadata and tasks:
```
      metadata:
        freshness:
          warn: "1 day"
          error: "48 hour"
```
The following syntax may be used:
```
    DAYS         -> "d day",
    HOURS        -> "h hr hour",
    MINUTES      -> "m min minute",
    SECONDS      -> "s sec second",
    MILLISECONDS -> "ms milli millisecond",
    MICROSECONDS -> "µs micro microsecond",
    NANOSECONDS  -> "ns nano nanosecond"
```
**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**
