### PR TITLE
Feat/add interpolation extract pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Release notes
 
-# 0.6.4
+# 0.7.0
 __New Feature__:
 - Add Project diffs and produce HTML report
 - Import existing BigQuery Datasets and Tables
@@ -11,8 +11,12 @@ __New Feature__:
 - Extract BigQuery Tables infos to dataset_info and table_info tables
 - Import BigQuery Project into external metadata folder
 - Automatically switch to ORC when ingesting complex structures (array of records) into bigquery (https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/251)
+- Turn schema extract pattern to a template
+- Add global jdbc schema attributes in order to set common attributes once
+- Always propagate domain's metadata to tables
 
 __Bug Fix__:
+- **BREAKING CHANGE**: Make directory mandatory only when feature require it. If you rely on exception while generating YML files from xls and vice-versa for any missing directory, you'll have to change. 
 - Upsert table description for nested fields
 - Restore the ability to override intermediate bq format
 - Exclude specific BQ partitions when applying Merge with a BQ Table

--- a/docs/docs/reference/15.extract.md
+++ b/docs/docs/reference/15.extract.md
@@ -64,6 +64,10 @@ connections {
 
 we may replace connectionRef tag by the connection tag and provide the connection options inline right inside the YAML configuration file as follows:
 
+:::note
+
+if you need to set common jdbc schema attributes, you can use globalJdbcSchema on the same level as jdbcSchemas and define the same attributes. Tables can't be set commonly.
+
 ````yaml
 extract:
     connection:

--- a/src/main/scala/ai/starlake/extract/ExtractSchema.scala
+++ b/src/main/scala/ai/starlake/extract/ExtractSchema.scala
@@ -53,14 +53,10 @@ object ExtractSchema extends Extract with LazyLogging {
           .richFormat(schemaHandler.activeEnv(), Map.empty)
         YamlSerializer.deserializeDomain(content, ymlTemplate) match {
           case Success(domain) =>
-            domain.metadata match {
-              case Some(metadata) if metadata.directory.isEmpty =>
-                throw new Exception(
-                  "Domain metadata directory property is mandatory in template file."
-                )
-              case Some(_) =>
-                domain
-            }
+            if (domain.resolveDirectoryOpt().isEmpty)
+              throw new Exception(
+                "Domain metadata directory property is mandatory in template file."
+              )
             domain
           case Failure(e) => throw e
         }

--- a/src/main/scala/ai/starlake/extract/JDBCUtils.scala
+++ b/src/main/scala/ai/starlake/extract/JDBCUtils.scala
@@ -302,10 +302,6 @@ object JDBCUtils extends LazyLogging {
     domainTemplate: Option[Domain],
     selectedTablesAndColumns: Map[String, (TableRemarks, Columns, PrimaryKeys)]
   ) = {
-    val domainMetadata =
-      domainTemplate.flatMap(_.metadata)
-    val patternTemplate =
-      domainTemplate.flatMap(_.tables.headOption.map(_.pattern))
     val trimTemplate =
       domainTemplate.flatMap(_.tables.headOption.flatMap(_.attributes.head.trim))
 

--- a/src/main/scala/ai/starlake/schema/generator/XlsDomainReader.scala
+++ b/src/main/scala/ai/starlake/schema/generator/XlsDomainReader.scala
@@ -54,12 +54,12 @@ class XlsDomainReader(input: Input) extends XlsModel {
           .flatMap(formatter.formatCellValue)
           .map(_.split(",").toList)
           .getOrElse(Nil)
-      (nameOpt, directoryOpt) match {
-        case (Some(name), Some(directory)) =>
+      nameOpt match {
+        case Some(name) =>
           Some(
             Domain(
               name,
-              metadata = Some(Metadata(directory = Some(directory), ack = ack)),
+              metadata = Some(Metadata(directory = directoryOpt, ack = ack)),
               comment = comment,
               tableRefs = schemaRefs,
               rename = renameOpt

--- a/src/main/scala/ai/starlake/schema/generator/Yml2Xls.scala
+++ b/src/main/scala/ai/starlake/schema/generator/Yml2Xls.scala
@@ -75,7 +75,7 @@ class Yml2Xls(schemaHandler: SchemaHandler) extends LazyLogging with XlsModel {
     fillHeaders(workbook, allDomainHeaders, domainSheet)
     val domainRow = domainSheet.createRow(2)
     domainRow.createCell(0).setCellValue(domain.name)
-    domainRow.createCell(1).setCellValue(domain.resolveDirectory())
+    domainRow.createCell(1).setCellValue(domain.resolveDirectoryOpt().getOrElse(""))
     domainRow.createCell(2).setCellValue(domain.resolveAck().getOrElse(""))
     domainRow.createCell(3).setCellValue(domain.comment.getOrElse(""))
     domainRow.createCell(4).setCellValue(domain.tableRefs.mkString(","))

--- a/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
@@ -441,7 +441,7 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
     }
 
     val directoryErrors = Utils.duplicates(
-      domains.map(_.resolveDirectory()),
+      domains.flatMap(_.resolveDirectoryOpt()),
       s"%s is defined %d times. A directory can only appear once in a domain definition file."
     ) match {
       case Right(_) =>

--- a/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
@@ -409,6 +409,7 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
               )
             }
             .flatMap(_.tables)
+            .map(t => t.copy(metadata = Some(t.mergedMetadata(domain.metadata))))
           logger.info(s"Successfully loaded Domain  in $path")
           Success(domain.copy(tables = Option(domain.tables).getOrElse(Nil) ::: schemaRefs))
         case (path, Failure(e)) =>

--- a/src/main/scala/ai/starlake/utils/YamlSerializer.scala
+++ b/src/main/scala/ai/starlake/utils/YamlSerializer.scala
@@ -69,7 +69,17 @@ object YamlSerializer extends LazyLogging {
         rootNode
       } else
         extractNode
-    mapper.treeToValue(jdbcNode, classOf[JDBCSchemas])
+    if (
+      jdbcNode
+        .path("globalJdbcSchema")
+        .isMissingNode && !jdbcNode.path("globalJdbcSchema").path("tables").isMissingNode
+    ) {
+      logger.warn(
+        "tables defined in globalJdbcSchema are ignored. Please define them in jdbcSchemas"
+      )
+    }
+    val jdbcSchemas = mapper.treeToValue(jdbcNode, classOf[JDBCSchemas])
+    jdbcSchemas.propageGlobalJdbcSchemas()
   }
 
   def serializeToFile(targetFile: File, domain: Domain): Unit = {

--- a/src/test/scala/ai/starlake/TestHelper.scala
+++ b/src/test/scala/ai/starlake/TestHelper.scala
@@ -67,10 +67,10 @@ trait TestHelper
 
   private lazy val cometTestPrefix: String = s"comet-test-${TestHelper.runtimeId}"
 
-  private lazy val cometTestInstanceId: String =
+  private def cometTestInstanceId: String =
     s"${this.getClass.getSimpleName}-${java.util.UUID.randomUUID()}"
 
-  lazy val cometTestId: String = s"${cometTestPrefix}-${cometTestInstanceId}"
+  def cometTestId: String = s"${cometTestPrefix}-${cometTestInstanceId}"
 
   lazy val cometTestRoot: String =
     Option(System.getProperty("os.name")).map(_.toLowerCase contains "windows") match {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.6.4-SNAPSHOT"
+ThisBuild / version := "0.7.0-SNAPSHOT"


### PR DESCRIPTION
## Summary
- Turn schema extract pattern to a template
- Add global jdbc schema attributes in order to set common attributes once
- Always propagate domain's metadata to tables
- SMALL BREAKING CHANGE**: Make directory mandatory only when feature require it. If you rely on exception while generating YML files from xls and vice-versa for any missing directory, you'll have to change.

**Related Issue: #IssueId**

**PR Type: Bug Fix | Feature | Documentation**

**Status: Ready to review**

**Breaking change? Yes**

### How has this been tested?
Add unit tests and use snapshot assembly for client case

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have updated the Release notes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.



