### PR TITLE
Update SPARK_TGZ_URL

### DIFF
--- a/distrib/starlake.cmd
+++ b/distrib/starlake.cmd
@@ -151,7 +151,7 @@ if "%SPARK_DOWNLOADED%" == "TRUE" (
 
 SET SPARK_DIR_NAME=spark-%SPARK_VERSION%-bin-hadoop%HADOOP_VERSION%
 SET SPARK_TGZ_NAME=%SPARK_DIR_NAME%.tgz
-SET SPARK_TGZ_URL=https://downloads.apache.org/spark/spark-%SPARK_VERSION%/%SPARK_TGZ_NAME%
+SET SPARK_TGZ_URL=https://archive.apache.org/dist/spark/spark-%SPARK_VERSION%/%SPARK_TGZ_NAME%
 SET SPARK_DIR=%SCRIPT_DIR%\%SPARK_DIR_NAME%
 
 if not exist %SPARK_TGZ_NAME% (

--- a/distrib/starlake.sh
+++ b/distrib/starlake.sh
@@ -20,7 +20,7 @@ export COMET_MAIN=ai.starlake.job.Main
 export COMET_VALIDATE_ON_LOAD=false
 
 SPARK_TGZ_NAME=$SPARK_DIR_NAME.tgz
-SPARK_TGZ_URL=https://downloads.apache.org/spark/spark-$SPARK_VERSION/$SPARK_TGZ_NAME
+SPARK_TGZ_URL=https://archive.apache.org/dist/spark/spark-$SPARK_VERSION/$SPARK_TGZ_NAME
 SPARK_BQ_URL=https://repo1.maven.org/maven2/com/google/cloud/spark/$SPARK_BQ_ARTIFACT_NAME/$SPARK_BQ_VERSION/$SPARK_BQ_ARTIFACT_NAME-$SPARK_BQ_VERSION.jar
 
 initStarlakeInstallVariables() {


### PR DESCRIPTION
## Summary
Currently the `SPARK_TGZ_URL` is using the https://downloads.apache.org to fetch spark but this url only hosts the current version of spark.

When following the Quickstart guide and running the `starlake.sh` the script does not work since it is not able to find the default version of spark set by the `SPARK_VERSION` variable. So instead of updating the version I'm proposing to update the URL it downloads from. This is what currently happens:

<details>
  <summary>docker build command execution</summary>

```
─❯  docker build -t starlake .
[+] Building 9.1s (11/11) FINISHED
 => [internal] load .dockerignore                                                                               0.0s
 => => transferring context: 2B                                                                                 0.0s
 => [internal] load build definition from Dockerfile                                                            0.0s
 => => transferring dockerfile: 736B                                                                            0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.10                                                 5.5s
 => [internal] load build context                                                                               0.0s
 => => transferring context: 33B                                                                                0.0s
 => [stage-1 1/7] FROM docker.io/library/ubuntu:22.10@sha256:699796ebf58f6d43889a7a2a29bcc8e421f8fa86bdc00d3ff  0.0s
 => CACHED [stage-1 2/7] RUN apt-get update     && apt-get -y install openjdk-17-jdk curl jq --no-install-reco  0.0s
 => CACHED [stage-1 3/7] RUN mkdir -p /app/starlake/                                                            0.0s
 => CACHED [stage-1 4/7] WORKDIR /app/starlake                                                                  0.0s
 => CACHED [stage-1 5/7] COPY starlake.sh /app/starlake                                                         0.0s
 => [stage-1 6/7] RUN chmod +x /app/starlake/starlake.sh                                                        0.5s
 => ERROR [stage-1 7/7] RUN /app/starlake/starlake.sh                                                           3.1s
------
 > [stage-1 7/7] RUN /app/starlake/starlake.sh:
#0 0.499 -------------------
#0 0.499    Current state
#0 0.499 -------------------
#0 1.208 - spark: KO
#0 1.208 - starlake: KO
#0 1.208 - spark bq: KO
#0 1.208
#0 1.208 -------------------
#0 1.208       Install
#0 1.208 -------------------
#0 1.213
#0 1.213 - spark: downloading from https://downloads.apache.org/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz
#0 1.219   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#0 1.219                                  Dload  Upload   Total   Spent    Left  Speed
  0   196    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
#0 1.867 curl: (22) The requested URL returned error: 404
#0 1.869 tar (child): /app/starlake/bin/spark-3.3.1-bin-hadoop3.tgz: Cannot open: No such file or directory
#0 1.869 tar (child): Error is not recoverable: exiting now
#0 1.869 tar: Child returned status 2
#0 1.869 tar: Error is not recoverable: exiting now
#0 1.872 mv: cannot stat '/app/starlake/bin/spark-3.3.1-bin-hadoop3': No such file or directory
#0 1.874 cp: cannot stat '/app/starlake/bin/spark/conf/log4j2.properties.template': No such file or directory
#0 1.875 - spark: OK
#0 1.875 - starlake: downloading from https://s01.oss.sonatype.org/content/repositories/releases/ai/starlake/starlake-spark3_2.12/0.6.3/starlake-spark3_2.12-0.6.3-assembly.jar
#0 1.881   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#0 1.881                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to open the file
#0 2.471 Warning: /app/starlake/bin/spark/jars/starlake-spark3_2.12-0.6.3-assembly.jar:
#0 2.471 Warning: No such file or directory
  0  135M    0 16138    0     0  27356      0  1:26:42 --:--:--  1:26:42 27352
#0 2.471 curl: (23) Failure writing output to destination
#0 2.473 - starlake: OK
#0 2.473 - spark bq: downloading from https://repo1.maven.org/maven2/com/google/cloud/spark/spark-bigquery-with-dependencies_2.12/0.27.1/spark-bigquery-with-dependencies_2.12-0.27.1.jar
#0 2.480   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#0 2.480                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to open the file
#0 3.059 Warning: /app/starlake/bin/spark/jars/spark-bigquery-with-dependencies_2.12-0.2
#0 3.059 Warning: 7.1.jar: No such file or directory
  0 33.9M    0  1402    0     0   2422      0  4:04:38 --:--:--  4:04:38  2425
#0 3.059 curl: (23) Failure writing output to destination
#0 3.061 - spark bq: OK
#0 3.061
#0 3.061 Launching starlake.
#0 3.061 - JAVA_HOME=
#0 3.061 - COMET_ROOT=/app/starlake
#0 3.061 - COMET_ENV=FS
#0 3.061 - COMET_FS=file://
#0 3.061 - COMET_MAIN=ai.starlake.job.Main
#0 3.061 - COMET_VALIDATE_ON_LOAD=false
#0 3.061 - SPARK_DRIVER_MEMORY=4G
#0 3.061 Make sure your java home path does not contain space
#0 3.061 /app/starlake/starlake.sh: line 144: /app/starlake/bin/spark/bin/spark-submit: No such file or directory
------
Dockerfile:28
--------------------
  26 |
  27 |     RUN chmod +x /app/starlake/starlake.sh
  28 | >>> RUN /app/starlake/starlake.sh
  29 |
  30 |     ENTRYPOINT ["/app/starlake/starlake.sh"]
--------------------
ERROR: failed to solve: process "/bin/sh -c /app/starlake/starlake.sh" did not complete successfully: exit code: 127
```
</details>

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
This changes the `SPARK_TGZ_URL` to point to https://archive.apache.org

### How has this been tested?
I've updated locally and ran the installation and it did installed successfully.

### Remaining Todos
This should be done before merging this PR:
* [ ] Update release notes

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] I have updated the Release notes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



