### PR TITLE
feat: continuation of optional directory attribute

### DIFF
--- a/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
@@ -932,8 +932,8 @@ trait IngestionJob extends SparkJob {
       settings.comet.scheduling.poolName
     )
 
-    val jobResult = domain.checkValidity(schemaHandler) match {
-      case Left(errors) =>
+    val jobResult = domain.checkValidity(schemaHandler, directorySeverity = Disabled) match {
+      case Left((errors, _)) =>
         val errs = errors.reduce { (errs, err) =>
           errs + "\n" + err
         }

--- a/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
@@ -59,13 +59,22 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
     new CometObjectMapper(new YAMLFactory(), injectables = (classOf[Settings], settings) :: Nil)
 
   @throws[Exception]
-  private def checkValidity(reload: Boolean = false): List[String] = {
+  private def checkValidity(
+    directorySeverity: Severity,
+    reload: Boolean = false
+  ): List[String] = {
+    def toWarning(warnings: List[String]) = {
+      warnings.map("Warning: " + _)
+    }
+
     val typesValidity = this.types(reload).map(_.checkValidity())
     val loadedDomains = this.domains(reload)
-    val domainsValidity = loadedDomains.map(_.checkValidity(this))
+    val domainsValidity = loadedDomains.map(_.checkValidity(this, directorySeverity)).map {
+      case Left((errors, warnings)) => Left(errors ++ toWarning(warnings))
+      case Right(right)             => Right(right)
+    }
     val domainsVarsValidity = checkDomainsVars()
-    val jobsVarsValidity =
-      checkJobsVars().map("Warning: " + _) // job vars may be defined at runtime.
+    val jobsVarsValidity = toWarning(checkJobsVars()) // job vars may be defined at runtime.
     val allErrors = typesValidity ++ domainsValidity :+ checkViewsValidity()
 
     val errs = allErrors.flatMap {
@@ -95,8 +104,11 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
     }
   }
 
-  def fullValidation(config: ValidateConfig = ValidateConfig(reload = false)): Unit = {
-    val validityErrorsAndWarnings = checkValidity(config.reload)
+  def fullValidation(
+    config: ValidateConfig = ValidateConfig()
+  ): Unit = {
+    val validityErrorsAndWarnings =
+      checkValidity(directorySeverity = Warning, reload = config.reload)
     val deserErrors = deserializedDomains(DatasetArea.domains)
       .filter { case (path, res) =>
         res.isFailure

--- a/src/main/scala/ai/starlake/schema/model/Severity.scala
+++ b/src/main/scala/ai/starlake/schema/model/Severity.scala
@@ -1,0 +1,6 @@
+package ai.starlake.schema.model
+
+trait Severity
+case object Error extends Severity
+case object Warning extends Severity
+case object Disabled extends Severity


### PR DESCRIPTION
## Summary
Continuation of optional directory attribute

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
The attribute directory can be defined in two locations, one in the root's domain and the other one is in the metadata as depict the function Domain#resolveDirectoryOpt.

Domain directory is read only by the above method.
Metadata directory is read by :
- Metadata#import: this method is used to merge domain's metadata with table's metadata
- resolveDirectoryOpt

We get a Metadata instance out of Metadata#import and as we can see from the usage analysis, no direct usage of the directory member is done apart from the method listed above.
Hence, we can say safely that directory is read either via Domain#resolveDirectory or resolveDirectoryOpt.

Domain#resolveDirectory currently throw an exception when directory is not resolved. This happen when :
- when load landing with the `import` command
- when we extract schema from database with the `extract-schema` command but to be precise, it is only called when the domainTemplate is set. Otherwise schema extraction can be executed without directory.

Domain#resolveDirectoryOpt is called by:
- ExtractSchema#run and is called when we want to extract schema from the database and before the one in JDBCUtils so the call to resolveDirectory will never throw an exception in the previous case for the moment since another check is done before.
- Yml2Xls#writeDomainXls: fallback to an empty directory if not resolved and no other usage is then done. The result is written to an xls file.
- SchemaHandler#loadDomains: is called to check if there is any directory shared among domains if directory is set.
- Domain#checkValidity: this method assertion results and expect directory to be mandatory. Add an error if doesn't.

Domain#checkValidity is called by:
- SchemaHandler#checkValidity: a private method that combine various errors into one list. This method is called by:
    - SchemaHandler#fullValidation: a public method that logs all errors but doesn't throw any exception. It is called by:
        - default for any command if the settings `comet.validateOnLoad` is set to true
        - `validate` command
    - IngestionJob#run: if there is any error happening on the validation phase, an exception is thrown. 
        - This method is overridden by any subclass. All subclass are instantiated on IngestionWorkflow#ingest.
        - Our previous directory analysis suggested that this attribute is only required by the import command so we can safely disable this check in this job.

From this analysis, we can state that missing directory can be considered as a warning in fullValidation method in order to have an "accurate" output and say that this attribute, if import is used, is mandatory and must be defined and disable this check in the ingestion job.

This PR apply the result of this analysis in order to make directory even more optional and have it required only if necessary.

### How has this been tested?
Used in our platform.

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have updated the Release notes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.



