### PR TITLE
Feat/enhance extract schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ __New Feature__:
 - Turn schema extract pattern to a template
 - Add global jdbc schema attributes in order to set common attributes once
 - Always propagate domain's metadata to tables
+- Turn numeric without scale as long while extracting schema
+- Order column extraction from extract-schema according to database column order
+- Set domain description if given on bigquery
 
 __Bug Fix__:
 - **BREAKING CHANGE**: Make directory mandatory only when feature require it. If you rely on exception while generating YML files from xls and vice-versa for any missing directory, you'll have to change. 
@@ -21,7 +24,9 @@ __Bug Fix__:
 - Restore the ability to override intermediate bq format
 - Exclude specific BQ partitions when applying Merge with a BQ Table
 - Apply spark options defined in the job description (sink) when saving into file
-- archived Spark versions may be now referenced in starlake CLI (@sabino). 
+- archived Spark versions may be now referenced in starlake CLI (@sabino).
+- Use gs if full uri is given even if default fs is file
+- Remove lowercase on various name in extract-script in order to make it coherent with extract-schema
 
 # 0.6.3
 __New Feature__:

--- a/src/main/scala/ai/starlake/extract/TemplateParams.scala
+++ b/src/main/scala/ai/starlake/extract/TemplateParams.scala
@@ -42,7 +42,7 @@ case class TemplateParams(
       case (name, tpe, ignore, privacyLevel) :: Nil =>
         List(
           Map(
-            "name"              -> name.toLowerCase(),
+            "name"              -> name,
             "type"              -> tpe,
             "trailing_col_char" -> "",
             "ignore"            -> ignore,
@@ -56,14 +56,14 @@ case class TemplateParams(
         allButLast
           .map { case (name, tpe, ignore, privacyLevel) =>
             Map(
-              "name"              -> name.toLowerCase(),
+              "name"              -> name,
               "type"              -> tpe,
               "ignore"            -> ignore,
               "privacyLevel"      -> privacyLevel.toString,
               "trailing_col_char" -> ","
             )
           } :+ Map(
-          "name"              -> lastName.toLowerCase(),
+          "name"              -> lastName,
           "type"              -> lastType,
           "ignore"            -> lastIgnore,
           "privacyLevel"      -> lastPrivacyLevel,
@@ -74,9 +74,9 @@ case class TemplateParams(
       .foldLeft(
         List(
           "domain"       -> domainToExport,
-          "table"        -> tableToExport.toLowerCase,
+          "table"        -> tableToExport,
           "domain_table" -> domainToExport, // For compatibility
-          "table_name"   -> tableToExport.toLowerCase, // For compatibility
+          "table_name"   -> tableToExport, // For compatibility
           "delimiter"    -> dsvDelimiter,
           "columns"      -> columnsParam,
           "full_export"  -> fullExport,

--- a/src/main/scala/ai/starlake/job/ingest/AuditLog.scala
+++ b/src/main/scala/ai/starlake/job/ingest/AuditLog.scala
@@ -245,7 +245,7 @@ object AuditLog extends StrictLogging {
           Some("Information related to starlake executions"),
           Some(bqSchema())
         )
-        bqJob.getOrCreateTable(tableInfo, None)
+        bqJob.getOrCreateTable(None, tableInfo, None)
         val res = bqJob.runBatchQuery()
         Utils.logFailure(res, logger)
       case _: EsSink =>

--- a/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
@@ -525,7 +525,8 @@ trait IngestionJob extends SparkJob {
             options = sink.map(_.getOptions).getOrElse(Map.empty),
             partitionsToUpdate = partitionsToUpdate,
             starlakeSchema = Some(schema),
-            domainTags = domain.tags
+            domainTags = domain.tags,
+            domainDescription = domain.comment
           )
           val res = new BigQuerySparkJob(
             config,

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryLoadConfig.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryLoadConfig.scala
@@ -27,6 +27,7 @@ case class BigQueryLoadConfig(
   acl: List[AccessControlEntry] = Nil,
   starlakeSchema: Option[Schema] = None,
   domainTags: Set[String] = Set.empty,
+  domainDescription: Option[String] = None,
   materializedView: Boolean = false
 ) extends GcpConnectionConfig
 

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
@@ -26,7 +26,7 @@ class BigQueryNativeJob(
 
   def runInteractiveQuery(): Try[JobResult] = {
     Try {
-      getOrCreateDataset()
+      getOrCreateDataset(cliConfig.domainDescription)
       val queryConfig: QueryJobConfiguration.Builder =
         QueryJobConfiguration
           .newBuilder(sql)
@@ -75,7 +75,7 @@ class BigQueryNativeJob(
   }
   private def RunAndSinkAsMaterializedView(): Try[Table] = {
     Try {
-      getOrCreateDataset()
+      getOrCreateDataset(None)
       val materializedViewDefinitionBuilder = MaterializedViewDefinition.newBuilder(sql)
       cliConfig.outputPartition match {
         case Some(partitionField) =>
@@ -106,7 +106,7 @@ class BigQueryNativeJob(
 
   private def RunAndSinkAsTable(): Try[BigQueryJobResult] = {
     Try {
-      val targetDataset = getOrCreateDataset()
+      val targetDataset = getOrCreateDataset(None)
       val queryConfig: QueryJobConfiguration.Builder =
         QueryJobConfiguration
           .newBuilder(sql)
@@ -163,7 +163,7 @@ class BigQueryNativeJob(
 
   def runBatchQuery(): Try[Job] = {
     Try {
-      getOrCreateDataset()
+      getOrCreateDataset(None)
       val jobId = JobId
         .newBuilder()
         .setJob(

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJob.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJob.scala
@@ -75,7 +75,11 @@ class BigQuerySparkJob(
         case Right(df) => df.persist(cacheStorageLevel)
       }
     }.flatMap(sourceDF =>
-      getOrCreateTable(TableInfo(tableId, maybeTableDescription, maybeSchema), Some(sourceDF))
+      getOrCreateTable(
+        cliConfig.domainDescription,
+        TableInfo(tableId, maybeTableDescription, maybeSchema),
+        Some(sourceDF)
+      )
         .map { case (table, _) => sourceDF -> table }
     ).map { case (sourceDF, table) =>
       val stdTableDefinition =

--- a/src/test/scala/ai/starlake/extract/ExtractSpec.scala
+++ b/src/test/scala/ai/starlake/extract/ExtractSpec.scala
@@ -59,9 +59,9 @@ class ExtractSpec extends TestHelper {
     val sql: String =
       """
         |drop table if exists test_table1;
-        |create table test_table1(ID INT PRIMARY KEY,NAME VARCHAR(500));
+        |create table test_table1(ID INT PRIMARY KEY,NAME VARCHAR(500), int_as_numeric NUMERIC(8,0), real_numeric NUMERIC(10,3), int_as_decimal DECIMAL(5,0), real_float FLOAT(2));
         |create view test_view1 AS SELECT NAME FROM test_table1;
-        |insert into test_table1 values (1,'A');""".stripMargin
+        |insert into test_table1 values (1,'A', 5, 1.5, 2, 2.6);""".stripMargin
     val st = conn.createStatement()
     st.execute(sql)
     val rs = st.executeQuery("select * from test_table1")
@@ -98,8 +98,14 @@ class ExtractSpec extends TestHelper {
       "_TEST_TABLE1",
       "_TEST_VIEW1"
     )
-    table.attributes.map(_.name) should contain theSameElementsAs Set("ID", "NAME")
-    table.attributes.map(_.`type`) should contain theSameElementsAs Set("long", "string")
+    table.attributes.map(a => a.name -> a.`type`).toSet should contain theSameElementsAs Set(
+      "ID"             -> "long",
+      "NAME"           -> "string",
+      "INT_AS_NUMERIC" -> "long",
+      "REAL_NUMERIC"   -> "decimal",
+      "INT_AS_DECIMAL" -> "long",
+      "REAL_FLOAT"     -> "double"
+    )
     table.primaryKey should contain("ID")
     table.pattern.pattern() shouldBe "PUBLIC-TEST_TABLE1.*"
     val viewFile = publicOutputDir / "_TEST_VIEW1.comet.yml"


### PR DESCRIPTION
## Summary
Feature :
- Order column extraction from extract-schema according to database column order
- Set domain description if given on bigquery

Fix: 
- use gs if full uri is given even if default fs is file
- remove lowercase on various name in extract-script in order to make it coherent with extract-schema

**PR Type: Bug Fix | Feature**

**Status: Ready to review**

**Breaking change? No**

### How has this been tested?
Unit tests have been modified for column extraction and used in client.
Domain description have been tested in our platform.
The lower case removal fix has been tested in our platform.
The gs have been tested from local to reach gcp via only COMET_ROOT and it works well.
The numeric precision test has been tested in unit tests.

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have updated the Release notes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.



