### PR TITLE
Use BQ load for simple cases

### DIFF
--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
@@ -28,7 +28,7 @@ class BigQueryNativeJob(
 
   logger.info(s"BigQuery Config $cliConfig")
 
-  def loadPathsToBQ(bqSchema: BQSchema) = {
+  def loadPathsToBQ(bqSchema: BQSchema): Try[BigQueryJobResult] = {
     Try {
       logger.info(s"BigQuery Schema: $bqSchema")
       val formatOptions: FormatOptions = bqFormatOptions()
@@ -84,7 +84,11 @@ class BigQueryNativeJob(
     }
   }
 
-  private def bqLoadConfig(bqSchema: BQSchema, formatOptions: FormatOptions, sourceURIs: String) = {
+  private def bqLoadConfig(
+    bqSchema: BQSchema,
+    formatOptions: FormatOptions,
+    sourceURIs: String
+  ): LoadJobConfiguration.Builder = {
     val loadConfig =
       LoadJobConfiguration
         .newBuilder(tableId, sourceURIs.split(",").toList.asJava, formatOptions)
@@ -122,7 +126,7 @@ class BigQueryNativeJob(
     loadConfig
   }
 
-  private def bqFormatOptions() = {
+  private def bqFormatOptions(): FormatOptions = {
     val formatOptions = cliConfig.starlakeSchema.flatMap(_.metadata) match {
       case Some(metadata) =>
         metadata.getFormat() match {


### PR DESCRIPTION
## Summary
For simple load we use the native bq load functionality for CSV and simple json files
Required AcceptAllValidator and BQ sink to be referenced in the YAML files.

Please note the following limitations:
BQ LOAD CSV/JSON limitations:
- Does not support multi char separator
- Only support YYYY-MM-DD format for date
- Only support YYYY-MM-DD h:mm:ss for timestamp
- Does not support advanced features (field renaming, field deletion, field addition, field transformation) in the YML
- Support BigQuery Schema update options
- Only support newline delimited JSON records
  
**PR Type: Feature**

**Status: WIP/Ready to review**

**Breaking change? No**
