### PR TITLE
Feat/keep original domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ __New Feature__:
 - Order column extraction from extract-schema according to database column order
 - Set domain description if given on bigquery
 - Add the ability to consider empty string as valid value for required String
+- **BREAKING CHANGE** Add `normalized_domain` variable for schema extraction. `domain` keep the original name.
+- keep user changes if set in domain's metadata or table information. Domain-template and other rules that apply to it still have higher precedence.
 
 __Bug Fix__:
 - **BREAKING CHANGE**: Make directory mandatory only when feature require it. If you rely on exception while generating YML files from xls and vice-versa for any missing directory, you'll have to change. 
@@ -31,6 +33,7 @@ __Bug Fix__:
 - **BREAKING CHANGE**: support other projectId for bqNativeJob:
 - close resources for schema extraction
 - escape replacement value
+- **BREAKING CHANGE** domain template in extract-schema is no more interpolated since we plan to use domains accross multiple environment
 
 # 0.6.3
 __New Feature__:

--- a/src/main/scala/ai/starlake/config/DatasetArea.scala
+++ b/src/main/scala/ai/starlake/config/DatasetArea.scala
@@ -22,6 +22,7 @@ package ai.starlake.config
 
 import ai.starlake.schema.handlers.StorageHandler
 import ai.starlake.utils.Formatter.RichFormatter
+import ai.starlake.utils.Utils
 import better.files.File
 import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
@@ -151,15 +152,11 @@ object DatasetArea extends StrictLogging {
   }
 
   def substituteDomainAndSchema(domain: String, schema: String, template: String): String = {
-    val normalizedDomainName = normalizeDomainName(domain)
+    val normalizedDomainName = Utils.keepAlphaNum(domain)
     template
       .replace("{{domain}}", domain)
       .replace("{{normalized_domain}}", normalizedDomainName)
       .replace("{{schema}}", schema)
-  }
-
-  def normalizeDomainName(domain: String): String = {
-    domain.replaceAll("[^\\p{Alnum}]", "_")
   }
 
   def discreteMetrics(domain: String, schema: String)(implicit settings: Settings): Path =

--- a/src/main/scala/ai/starlake/config/DatasetArea.scala
+++ b/src/main/scala/ai/starlake/config/DatasetArea.scala
@@ -140,12 +140,27 @@ object DatasetArea extends StrictLogging {
   def replay(domain: String)(implicit settings: Settings): Path =
     path(domain, settings.comet.area.replay)
 
-  def substituteDomainAndSchemaInPath(domain: String, schema: String, path: String): Path =
+  def substituteDomainAndSchemaInPath(
+    domain: String,
+    schema: String,
+    path: String
+  ): Path = {
     new Path(
-      path
-        .replace("{{domain}}", domain)
-        .replace("{{schema}}", schema)
+      substituteDomainAndSchema(domain, schema, path)
     )
+  }
+
+  def substituteDomainAndSchema(domain: String, schema: String, template: String): String = {
+    val normalizedDomainName = normalizeDomainName(domain)
+    template
+      .replace("{{domain}}", domain)
+      .replace("{{normalized_domain}}", normalizedDomainName)
+      .replace("{{schema}}", schema)
+  }
+
+  def normalizeDomainName(domain: String): String = {
+    domain.replaceAll("[^\\p{Alnum}]", "_")
+  }
 
   def discreteMetrics(domain: String, schema: String)(implicit settings: Settings): Path =
     new Path(metrics(domain, schema), "discrete")

--- a/src/main/scala/ai/starlake/extract/ExtractSchema.scala
+++ b/src/main/scala/ai/starlake/extract/ExtractSchema.scala
@@ -49,7 +49,6 @@ object ExtractSchema extends Extract with LazyLogging {
       val domainTemplate = jdbcSchema.template.map { ymlTemplate =>
         val content = settings.storageHandler
           .read(mappingPath(ymlTemplate))
-          .richFormat(schemaHandler.activeEnv(), Map.empty)
         YamlSerializer.deserializeDomain(content, ymlTemplate) match {
           case Success(domain) =>
             if (domain.resolveDirectoryOpt().isEmpty)

--- a/src/main/scala/ai/starlake/extract/JDBCUtils.scala
+++ b/src/main/scala/ai/starlake/extract/JDBCUtils.scala
@@ -2,6 +2,7 @@ package ai.starlake.extract
 
 import ai.starlake.config.{DatasetArea, Settings}
 import ai.starlake.schema.model.{Attribute, Domain, Schema}
+import ai.starlake.utils.Utils
 import better.files.File
 import com.typesafe.scalalogging.LazyLogging
 
@@ -349,8 +350,10 @@ object JDBCUtils extends LazyLogging {
 
     val cometSchema = selectedTablesAndColumns.map {
       case (tableName, (tableRemarks, selectedColumns, primaryKeys)) =>
+        val sanitizedTableName = Utils.keepAlphaNum(tableName)
         Schema(
           name = tableName,
+          rename = if (sanitizedTableName != tableName) Some(sanitizedTableName) else None,
           pattern = Pattern.compile(s"$tableName.*"),
           attributes = selectedColumns.map(_.copy(trim = trimTemplate)),
           metadata = None,
@@ -375,7 +378,7 @@ object JDBCUtils extends LazyLogging {
       }
       .getOrElse(s"/${jdbcSchema.schema}")
 
-    val normalizedDomainName = DatasetArea.normalizeDomainName(jdbcSchema.schema)
+    val normalizedDomainName = Utils.keepAlphaNum(jdbcSchema.schema)
     val rename = domainTemplate
       .flatMap(_.rename)
       .map { name =>

--- a/src/main/scala/ai/starlake/schema/model/Domain.scala
+++ b/src/main/scala/ai/starlake/schema/model/Domain.scala
@@ -216,6 +216,12 @@ import scala.util.Try
 
     // Check Domain name validity
     val forceDomainPrefixRegex = settings.comet.forceDomainPattern.r
+    // TODO: name doesn't need to respect the pattern because it may be renamed. Restriction is based on target database restriction.
+    // We may check depending on the sink type but we may sink differently for each table.
+    // It would be better to assume a starlake pattern to describe a dataset and the container of the dataset such as the bigquery syntax project:dataset
+    // and then apply this syntax to all databases even if natively they don't accept that.
+    // Therefore, it means that we need to adapt on writing to the database, the target name.
+    // The same applies to table name.
     if (!forceDomainPrefixRegex.pattern.matcher(name).matches())
       errorList += s"Domain with name $name should respect the pattern ${forceDomainPrefixRegex.regex}"
 

--- a/src/main/scala/ai/starlake/schema/model/Metadata.scala
+++ b/src/main/scala/ai/starlake/schema/model/Metadata.scala
@@ -336,4 +336,10 @@ object Metadata {
     */
   val CometPartitionColumns =
     List("comet_date", "comet_year", "comet_month", "comet_day", "comet_hour", "comet_minute")
+
+  /** Merge all metadata into one. End of list element have higher precedence.
+    */
+  def mergeAll(metadatas: List[Metadata]): Metadata = {
+    metadatas.foldLeft(Metadata())(_.`import`(_))
+  }
 }

--- a/src/main/scala/ai/starlake/schema/model/Schema.scala
+++ b/src/main/scala/ai/starlake/schema/model/Schema.scala
@@ -415,6 +415,32 @@ case class Schema(
     }
   }
 
+  /** @param fallbackSchema
+    *   complete missing information with this schema
+    * @param domainMetadata
+    *   metadata to compare with. Useful to keep only things that are different.
+    * @return
+    *   merged schema
+    */
+  def mergeWith(fallbackSchema: Schema, domainMetadata: Option[Metadata] = None) = {
+    this.copy(
+      rename = this.rename.orElse(fallbackSchema.rename),
+      comment = this.comment.orElse(fallbackSchema.comment),
+      metadata = Metadata
+        .mergeAll(Nil ++ domainMetadata ++ fallbackSchema.metadata ++ this.metadata)
+        .`keepIfDifferent`(domainMetadata.getOrElse(Metadata()))
+        .asOption(),
+      merge = this.merge.orElse(fallbackSchema.merge),
+      presql = if (this.presql.isEmpty) fallbackSchema.presql else this.presql,
+      postsql = if (this.postsql.isEmpty) fallbackSchema.postsql else this.postsql,
+      tags = if (this.tags.isEmpty) fallbackSchema.tags else this.tags,
+      rls = if (this.rls.isEmpty) fallbackSchema.rls else this.rls,
+      assertions = if (this.assertions.isEmpty) fallbackSchema.assertions else this.assertions,
+      acl = if (this.acl.isEmpty) fallbackSchema.acl else this.acl,
+      sample = this.sample.orElse(fallbackSchema.sample)
+    )
+  }
+
 }
 
 object Schema {

--- a/src/main/scala/ai/starlake/utils/Utils.scala
+++ b/src/main/scala/ai/starlake/utils/Utils.scala
@@ -299,4 +299,8 @@ object Utils {
     // apply new schema
     df.sqlContext.createDataFrame(df.rdd, newSchema)
   }
+
+  def keepAlphaNum(domain: String): String = {
+    domain.replaceAll("[^\\p{Alnum}]", "_")
+  }
 }

--- a/src/test/scala/ai/starlake/extract/ExtractSpec.scala
+++ b/src/test/scala/ai/starlake/extract/ExtractSpec.scala
@@ -73,7 +73,8 @@ class ExtractSpec extends TestHelper {
       jdbcSchema,
       connectionOptions,
       outputDir,
-      domainTemplate
+      domainTemplate,
+      None
     )
     val publicOutputDir = outputDir / "PUBLIC"
     val publicPath = publicOutputDir / "PUBLIC.comet.yml"
@@ -336,6 +337,7 @@ class ExtractSpec extends TestHelper {
         ).fillWithDefaultValues(),
         settings.comet.connections("test-h2").options,
         File("/tmp"),
+        None,
         None
       )
       val publicPath = File("/tmp/PUBLIC/PUBLIC.comet.yml")
@@ -398,6 +400,7 @@ class ExtractSpec extends TestHelper {
         ).fillWithDefaultValues(),
         settings.comet.connections("test-h2").options,
         File("/tmp"),
+        None,
         None
       )
       val publicPath = File("/tmp/PUBLIC/PUBLIC.comet.yml")


### PR DESCRIPTION
## Summary
FEAT

- **BREAKING CHANGE** Add `normalized_domain` variable for schema extraction. `domain` keep the original name.
- keep user changes if set in domain's metadata or table information. Domain-template and other rules that apply to it still have higher precedence.

FIX
- **BREAKING CHANGE** domain template in extract-schema is no more interpolated since we plan to use domains accross multiple environment
