### PR TITLE
feat: trim on numeric for schema extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ __New Feature__:
 - Order column extraction from extract-schema according to database column order
 - Set domain description if given on bigquery
 - Add the ability to consider empty string as valid value for required String
+- Apply trim on all numeric during schema extraction. Have higher precedence than the one defined in the template.
 
 __Bug Fix__:
 - **BREAKING CHANGE**: Make directory mandatory only when feature require it. If you rely on exception while generating YML files from xls and vice-versa for any missing directory, you'll have to change. 

--- a/src/main/scala/ai/starlake/extract/JDBCSchemas.scala
+++ b/src/main/scala/ai/starlake/extract/JDBCSchemas.scala
@@ -1,6 +1,6 @@
 package ai.starlake.extract
 
-import ai.starlake.schema.model.WriteMode
+import ai.starlake.schema.model.{Trim, WriteMode}
 
 case class JDBCSchemas(
   jdbcSchemas: List[JDBCSchema],
@@ -40,7 +40,8 @@ case class JDBCSchemas(
               else schema.tableTypes,
             template = schema.template.orElse(globalJdbcSchema.flatMap(_.template)),
             write = schema.write.orElse(globalJdbcSchema.flatMap(_.write)),
-            pattern = schema.pattern.orElse(globalJdbcSchema.flatMap(_.pattern))
+            pattern = schema.pattern.orElse(globalJdbcSchema.flatMap(_.pattern)),
+            numericTrim = schema.numericTrim.orElse(globalJdbcSchema.flatMap(_.numericTrim))
           )
           .fillWithDefaultValues()
       }))
@@ -71,7 +72,8 @@ case class JDBCSchema(
   tableTypes: List[String] = Nil,
   template: Option[String] = None,
   write: Option[WriteMode] = None,
-  pattern: Option[String] = None
+  pattern: Option[String] = None,
+  numericTrim: Option[Trim] = None
 ) {
   def this() = this(None) // Should never be called. Here for Jackson deserialization only
 


### PR DESCRIPTION
Apply trim on all numeric during schema extraction. Have higher precedence than the one defined in the template.