### PR TITLE
bug fix for writing partitions

### DIFF
--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryJobBase.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryJobBase.scala
@@ -332,12 +332,6 @@ trait BigQueryJobBase extends StrictLogging {
       val tableDefinition = getTableDefinition(tableInfo, dataFrame)
       val table = scala
         .Option(bigquery().getTable(tableId))
-        /*.map(t => {
-          val out =
-            updateTableDescriptions(t, tableInfo.maybeTableDescription, Some(tableDefinition))
-          logger.info(s"Table ${tableId.getDataset}.${tableId.getTable} updated successfully")
-          out
-        }) */
         .getOrElse {
           val bqTableInfo = BQTableInfo
             .newBuilder(tableId, tableDefinition)
@@ -380,17 +374,6 @@ trait BigQueryJobBase extends StrictLogging {
       .setDescription(
         description
       )
-      .build()
-      .update()
-  }
-  protected def updateTableDescriptions(
-    table: Table,
-    maybeTableDescription: scala.Option[String],
-    maybeTableDefinition: scala.Option[TableDefinition]
-  ): Table = {
-    table.toBuilder
-      .setDescription(maybeTableDescription.orNull)
-      .setDefinition(maybeTableDefinition.orNull)
       .build()
       .update()
   }

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryLoadConfig.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryLoadConfig.scala
@@ -35,7 +35,7 @@ case class BigQueryLoadConfig(
   domainTags: Set[String] = Set.empty,
   domainDescription: Option[String] = None,
   materializedView: Boolean = false,
-  outputTableDesc: String = "",
+  outputTableDesc: Option[String] = None,
   sqlSource: Option[String] = None,
   attributesDesc: List[AttributeDesc] = Nil
 ) extends GcpConnectionConfig

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
@@ -285,8 +285,8 @@ class BigQueryNativeJob(
         Utils.logException(logger, e)
         throw new Exception(e)
       }
-      updateTableDescription(tableId)
-      updateColumnsDescription(sql)
+      updateTableDescription(tableId, cliConfig.outputTableDesc.getOrElse(""))
+      updateColumnsDescription(getFieldsDescriptionSource(sql))
       BigQueryJobResult(Some(results), totalBytesProcessed)
     }
   }

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJob.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJob.scala
@@ -251,8 +251,10 @@ class BigQuerySparkJob(
             .fields
             .map(f => f.name -> f.getComment().getOrElse(""))
             .toMap[String, String]
-        case (Some(_), Some(_)) =>
-          throw new Exception("should never happen, sqlSource and Schema cannot be set together.")
+        case (_, _) =>
+          throw new Exception(
+            "Should never happen, SqlSource or TableSchema should be set exclusively"
+          )
       }
       updateColumnsDescription(fieldsDescription)
       // TODO verify if there is a difference between maybeTableDescription, schema.comment , task.desc

--- a/src/main/scala/ai/starlake/job/transform/AutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/AutoTask.scala
@@ -144,7 +144,7 @@ case class AutoTask(
         sink.asInstanceOf[BigQuerySink].materializedView.getOrElse(false)
       ),
       attributesDesc = taskDesc.attributesDesc,
-      outputTableDesc = taskDesc.comment.getOrElse(""),
+      outputTableDesc = taskDesc.comment,
       starlakeSchema = Some(Schema.fromTaskDesc(taskDesc))
     )
   }

--- a/src/main/scala/ai/starlake/schema/model/AutoJobDesc.scala
+++ b/src/main/scala/ai/starlake/schema/model/AutoJobDesc.scala
@@ -66,7 +66,7 @@ case class AutoTaskDesc(
   coalesce: Option[Boolean] = None,
   freshness: Option[Freshness] = None,
   attributesDesc: List[AttributeDesc] = Nil,
-  python: Option[Path]
+  python: Option[Path] = None
 ) extends Named {
 
   def checkValidity(): Either[List[String], Boolean] = {

--- a/src/test/resources/sample/bq-integration-tests/tableWithPartitions.comet.yml
+++ b/src/test/resources/sample/bq-integration-tests/tableWithPartitions.comet.yml
@@ -1,0 +1,15 @@
+transform:
+  tasks:
+    - domain: BQ_TEST_DS
+      table: BQ_TEST_TABLE
+      write: OVERWRITE
+      sink:
+        type: BQ
+        timestamp: DOB
+      sql: |
+        WITH _table as (
+          select "joe" as name,Date("2022-01-01") as dob
+          union all
+          select "sam" as name, Date("2023-02-01") as dob
+        )
+        select * from _table

--- a/src/test/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJobSpec.scala
+++ b/src/test/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJobSpec.scala
@@ -1,11 +1,31 @@
 package ai.starlake.job.sink.bigquery
 
 import ai.starlake.TestHelper
-import com.google.cloud.bigquery.TableId
+import ai.starlake.config.Settings
+import ai.starlake.job.transform.TransformConfig
+import ai.starlake.schema.handlers.{SchemaHandler, SimpleLauncher}
+import ai.starlake.schema.model.{AutoJobDesc, AutoTaskDesc, BigQuerySink, WriteMode}
+import ai.starlake.workflow.IngestionWorkflow
+import com.google.cloud.bigquery.{BigQueryOptions, StandardTableDefinition, Table, TableId}
+import org.apache.hadoop.fs.Path
+import org.scalatest.BeforeAndAfterAll
 
-// TODO
-class BigQuerySparkJobSpec extends TestHelper {
-  if (false && sys.env.getOrElse("COMET_GCP_TEST", "false").toBoolean) {
+class BigQuerySparkJobSpec extends TestHelper with BeforeAndAfterAll {
+  val bigquery = BigQueryOptions.newBuilder().build().getService()
+  override def beforeAll(): Unit = {
+    if (sys.env.getOrElse("COMET_GCP_TEST", "false").toBoolean) {
+      bigquery.delete(TableId.of("BQ_TEST_DS", "BQ_TEST_TABLE"))
+    }
+  }
+  override def afterAll(): Unit = {
+    if (sys.env.getOrElse("COMET_GCP_TEST", "false").toBoolean) {
+      // BigQueryJobBase.bigquery.delete(TableId.of("bqtest", "account"))
+    }
+  }
+  if (sys.env.getOrElse("COMET_GCP_TEST", "false").toBoolean) {
+    // TODO
+    // import com.google.cloud.bigquery.TableId
+    /*
     it should "get table with a dataset name including project" in {
       val tableMetadata = BigQuerySparkJob.getTable("my-project:my-dataset.my-table")
       tableMetadata.table.get.getTableId shouldBe TableId.of("my-project", "my-dataset", "my-table")
@@ -15,6 +35,68 @@ class BigQuerySparkJobSpec extends TestHelper {
       val tableMetadata = BigQuerySparkJob.getTable("my-dataset.my-table")
       tableMetadata.table.get.getTableId.getDataset shouldBe "my-dataset"
       tableMetadata.table.get.getTableId.getTable shouldBe "my-table"
+    }*/
+    it should "overwrite partitions dynamically" in {
+      new WithSettings() {
+        new SpecTrait(
+          domainOrJobFilename = "tableWithPartitions.comet.yml",
+          sourceDomainOrJobPathname = "/sample/bq-integration-tests/tableWithPartitions.comet.yml",
+          datasetDomainName = "BQ_TEST_DS",
+          sourceDatasetPathName = "",
+          isDomain = false
+        ) {
+          val query =
+            """
+              |WITH _table as (
+              |  select "sam" as name,Date("1990-01-01") as dob
+              |  union all
+              |  select "joe" as name, Date("1992-02-01") as dob
+              |)
+              |select * from _table
+              |""".stripMargin
+          val businessTask1 = AutoTaskDesc(
+            "",
+            Some(query),
+            "BQ_TEST_DS",
+            "BQ_TEST_TABLE",
+            WriteMode.OVERWRITE,
+            sink = Some(BigQuerySink(name = Some("sinktest"), timestamp = Some("DOB")))
+          )
+          val businessJob =
+            AutoJobDesc(
+              "addPartitionsWithOverwrite",
+              List(businessTask1),
+              Nil,
+              None,
+              None,
+              None
+            )
+          cleanMetadata
+          cleanDatasets
+          val schemaHandler = new SchemaHandler(metadataStorageHandler)
+          val validator = new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher())
+          validator.autoJob(TransformConfig("tableWithPartitions")) shouldBe true
+
+          val businessJobDef = mapper
+            .writer()
+            .withAttribute(classOf[Settings], settings)
+            .writeValueAsString(businessJob)
+          val pathBusiness =
+            new Path(cometMetadataPath + "/jobs/addPartitionsWithOverwrite.comet.yml")
+          storageHandler.write(businessJobDef, pathBusiness)
+          private val table: Table = bigquery.getTable(TableId.of("BQ_TEST_DS", "BQ_TEST_TABLE"))
+          table.getNumRows.intValue() shouldBe 2
+          table.getDefinition[StandardTableDefinition].getTimePartitioning.getField shouldBe "DOB"
+
+          /*val schemaHandler = new SchemaHandler(metadataStorageHandler)
+
+          val workflow =
+            new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher())
+          val config = TransformConfig("bqjobtest")
+          workflow.autoJob(config) should be(true)
+           */
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix sinking to BigQuery when using _Dynamic Partition Overwrite_ mode. In this case we have to write partitions sequentially else wise all existing partitions in the table will be deleted. 
- Change  the approach of update a BigQuery table
   1. Schema updates are now done when writing data to the table (with the help of BigQuery schema_update_option) and not before, except for Merge mode.
   2. Updating Table descriptions and Columns description is done after writing data to table and not before. The update only targets the descriptions, instead of updating the whole table definition. The previous approach changed the the order of the columns in some cases. 

**PR Type: Bug Fix / Feature**

**Status:Ready to review**

**Breaking change? No**


## Description
### Solution
_check summary_

### How has this been tested?
New tests in code and tests at client

### Remaining Todos
This should be done before merging this PR:
* [ ] - finish TODO added

## Contributor checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the Release notes.

