### PR TITLE
add log

### DIFF
--- a/src/main/scala/ai/starlake/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/ai/starlake/workflow/IngestionWorkflow.scala
@@ -383,6 +383,9 @@ class IngestionWorkflow(
       )
       (schema, path)
     }
+    if (schemas.isEmpty) {
+      logger.info(s"No Files found to ingest.")
+    }
     schemas.partition { case (schema, _) => schema.isDefined }
   }
 


### PR DESCRIPTION
When we filter on domain or table, we don't have information about filtered files.

Adding a new log to know when no files matched.