### PR TITLE
fix: restore default value

### DIFF
--- a/src/main/scala/ai/starlake/schema/model/Metadata.scala
+++ b/src/main/scala/ai/starlake/schema/model/Metadata.scala
@@ -145,7 +145,7 @@ case class Metadata(
     getFinalValue(array.map(_.booleanValue()), false)
 
   def isWithHeader(): java.lang.Boolean =
-    getFinalValue(withHeader.map(_.booleanValue()), false)
+    getFinalValue(withHeader.map(_.booleanValue()), true)
 
   def getSeparator(): String = getFinalValue(separator, ";")
 


### PR DESCRIPTION
withHeader was mistakenly set as false but was historically set as true. Restore default value