### PR TITLE
Feat/add more options to extract data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 
 # Release notes
 
+# 0.7.2:
+__Feature__:
+- allow full export for tables and use partition column only to speed up extraction
+- allow to force full export. Useful for re-init cases.
+
+__Bug Fix__:
+- Use audit connection settings while fetching last export and its column quotes
+- Division by zero when computing progress bar
+- Human Readable throw exception when elapsed time is 0
+- **Breaking Change** Make table's fetchSize to have higher precedence than the one defined in jdbcSchema.
+
 # 0.7.1:
 __Feature__:
 - add support for parallel fetch with String in some databases and give the ability to customize it.

--- a/docs/docs/cli/extract-data.md
+++ b/docs/docs/cli/extract-data.md
@@ -18,8 +18,9 @@ Parameter|Cardinality|Description
 --mapping:`<value>`|*Required*|Database tables & connection info
 --limit:`<value>`|*Optional*|Limit number of records
 --numPartitions:`<value>`|*Optional*|parallelism level regarding partitionned tables
---parallelism:`<value>`|*Optional*|parallelism level of the extraction process. By default equals to the available cores: 10
+--parallelism:`<value>`|*Optional*|parallelism level of the extraction process. By default equals to the available cores: 12
 --separator:`<value>`|*Optional*|Column separator
 --clean:`<value>`|*Optional*|Cleanup output directory first ?
 --output-dir:`<value>`|*Required*|Where to output csv files
+--fullExport:`<value>`|*Optional*|Force full export to all tables
 

--- a/src/main/scala/ai/starlake/extract/ExtractData.scala
+++ b/src/main/scala/ai/starlake/extract/ExtractData.scala
@@ -50,7 +50,8 @@ class ExtractData(schemaHandler: SchemaHandler) extends Extract with LazyLogging
         config.separator,
         config.numPartitions,
         config.clean,
-        config.parallelism.getOrElse(Runtime.getRuntime.availableProcessors())
+        config.parallelism.getOrElse(Runtime.getRuntime.availableProcessors()),
+        config.fullExport
       )
     }
   }

--- a/src/main/scala/ai/starlake/extract/ExtractDataConfig.scala
+++ b/src/main/scala/ai/starlake/extract/ExtractDataConfig.scala
@@ -29,7 +29,8 @@ case class ExtractDataConfig(
   separator: Char = ';',
   numPartitions: Int = 1,
   parallelism: Option[Int] = None,
-  clean: Boolean = false
+  clean: Boolean = false,
+  fullExport: Boolean = false
 )
 
 object ExtractDataConfig extends CliConfig[ExtractDataConfig] {
@@ -70,7 +71,11 @@ object ExtractDataConfig extends CliConfig[ExtractDataConfig] {
       opt[String]("output-dir")
         .action((x, c) => c.copy(outputDir = Some(x)))
         .required()
-        .text("Where to output csv files")
+        .text("Where to output csv files"),
+      opt[Unit]("fullExport")
+        .action((x, c) => c.copy(fullExport = true))
+        .optional()
+        .text("Force full export to all tables")
     )
   }
 

--- a/src/main/scala/ai/starlake/extract/JDBCSchemas.scala
+++ b/src/main/scala/ai/starlake/extract/JDBCSchemas.scala
@@ -52,7 +52,8 @@ case class JDBCSchemas(
               else schema.connectionOptions,
             fetchSize = schema.fetchSize.orElse(globalJdbcSchema.flatMap(_.fetchSize)),
             stringPartitionFunc =
-              schema.stringPartitionFunc.orElse(globalJdbcSchema.flatMap(_.stringPartitionFunc))
+              schema.stringPartitionFunc.orElse(globalJdbcSchema.flatMap(_.stringPartitionFunc)),
+            fullExport = schema.fullExport.orElse(globalJdbcSchema.flatMap(_.fullExport))
           )
           .fillWithDefaultValues()
       }))
@@ -89,7 +90,8 @@ case class JDBCSchema(
   numPartitions: Option[Int] = None,
   connectionOptions: Map[String, String] = Map.empty,
   fetchSize: Option[Int] = None,
-  stringPartitionFunc: Option[String] = None
+  stringPartitionFunc: Option[String] = None,
+  fullExport: Option[Boolean] = None
 ) {
   def this() = this(None) // Should never be called. Here for Jackson deserialization only
 
@@ -97,7 +99,8 @@ case class JDBCSchema(
 
   def fillWithDefaultValues(): JDBCSchema = {
     copy(
-      tableTypes = if (tableTypes.isEmpty) JDBCSchema.defaultTableTypes else tableTypes
+      tableTypes = if (tableTypes.isEmpty) JDBCSchema.defaultTableTypes else tableTypes,
+      fullExport = Some(false)
     )
   }
 }
@@ -125,7 +128,8 @@ case class JDBCTable(
   partitionColumn: Option[String],
   numPartitions: Option[Int],
   connectionOptions: Map[String, String],
-  fetchSize: Option[Int]
+  fetchSize: Option[Int],
+  fullExport: Option[Boolean]
 ) {
   def this() =
     this(
@@ -134,6 +138,7 @@ case class JDBCTable(
       None,
       None,
       Map.empty,
+      None,
       None
     ) // Should never be called. Here for Jackson deserialization only
 }

--- a/src/main/scala/ai/starlake/extract/JDBCUtils.scala
+++ b/src/main/scala/ai/starlake/extract/JDBCUtils.scala
@@ -1185,6 +1185,10 @@ object LastExportUtils extends LazyLogging {
             }
           }
         }
+      case PrimitiveType.string if stringPartitionFuncTpl.isEmpty =>
+        throw new Exception(
+          s"Unsupported type $partitionColumnType for column partition column $partitionColumn in table $domain.$table. You may define your own hash to int function via stringPartitionFunc in jdbcSchema in order to support parallel fetch. Eg: abs( hashtext({{col}}) % {{nb_partitions}} )"
+        )
       case _ =>
         throw new Exception(
           s"Unsupported type $partitionColumnType for column partition column $partitionColumn in table $domain.$table"

--- a/src/main/scala/ai/starlake/utils/Utils.scala
+++ b/src/main/scala/ai/starlake/utils/Utils.scala
@@ -324,31 +324,35 @@ object Utils {
   }
 
   def toHumanElapsedTime(elapsedTimeMs: Long): String = {
-    val (output, _) = List(
-      "d"  -> 1000 * 60 * 60 * 24,
-      "h"  -> 1000 * 60 * 60,
-      "m"  -> 1000 * 60,
-      "s"  -> 1000,
-      "ms" -> 0
-    ).foldLeft("" -> elapsedTimeMs) { case ((output, timeMs), (unitSuffix, unitInMs)) =>
-      if (elapsedTimeMs < unitInMs)
-        output -> timeMs
-      else {
-        val (elapsedTimeInUnit, restOfTimeMs) = if (unitInMs > 0) {
-          val timeAsUnit = timeMs / unitInMs
-          val restOfTimeMs = timeMs % unitInMs
-          timeAsUnit -> restOfTimeMs
-        } else {
-          timeMs -> 0L
-        }
-        if (elapsedTimeInUnit > 0) {
-          s"$output $elapsedTimeInUnit$unitSuffix" -> restOfTimeMs
-        } else {
-          output -> restOfTimeMs
+    if (elapsedTimeMs == 0) {
+      "0 ms"
+    } else {
+      val (output, _) = List(
+        "d"  -> 1000 * 60 * 60 * 24,
+        "h"  -> 1000 * 60 * 60,
+        "m"  -> 1000 * 60,
+        "s"  -> 1000,
+        "ms" -> 0
+      ).foldLeft("" -> elapsedTimeMs) { case ((output, timeMs), (unitSuffix, unitInMs)) =>
+        if (elapsedTimeMs < unitInMs)
+          output -> timeMs
+        else {
+          val (elapsedTimeInUnit, restOfTimeMs) = if (unitInMs > 0) {
+            val timeAsUnit = timeMs / unitInMs
+            val restOfTimeMs = timeMs % unitInMs
+            timeAsUnit -> restOfTimeMs
+          } else {
+            timeMs -> 0L
+          }
+          if (elapsedTimeInUnit > 0) {
+            s"$output $elapsedTimeInUnit$unitSuffix" -> restOfTimeMs
+          } else {
+            output -> restOfTimeMs
+          }
         }
       }
+      // remove first space introduced by first concatenation
+      output.tail
     }
-    // remove first space introduced by first concatenation
-    output.tail
   }
 }

--- a/src/test/scala/ai/starlake/extract/ExtractSpec.scala
+++ b/src/test/scala/ai/starlake/extract/ExtractSpec.scala
@@ -155,9 +155,9 @@ class ExtractSpec extends TestHelper {
             catalog = Some("business"),
             schema = "public",
             tables = List(
-              JDBCTable("user", List("id", "email"), None, None, Map.empty, None),
-              JDBCTable("product", Nil, None, None, Map.empty, None),
-              JDBCTable("*", Nil, None, None, Map.empty, None)
+              JDBCTable("user", List("id", "email"), None, None, Map.empty, None, None),
+              JDBCTable("product", Nil, None, None, Map.empty, None, None),
+              JDBCTable("*", Nil, None, None, Map.empty, None, None)
             ),
             tableTypes = List(
               "TABLE",
@@ -214,16 +214,17 @@ class ExtractSpec extends TestHelper {
             catalog = Some("business"),
             schema = "public",
             tables = List(
-              JDBCTable("user", List("id", "email"), None, None, Map.empty, None),
-              JDBCTable("product", Nil, None, None, Map.empty, None),
-              JDBCTable("*", Nil, None, None, Map.empty, None)
+              JDBCTable("user", List("id", "email"), None, None, Map.empty, None, None),
+              JDBCTable("product", Nil, None, None, Map.empty, None, None),
+              JDBCTable("*", Nil, None, None, Map.empty, None, None)
             ),
             tableTypes = List(
               "TABLE",
               "VIEW"
             ),
             template = Some("/my-templates/domain-template.yml"),
-            pattern = Some("{{schema}}-{{table}}.*")
+            pattern = Some("{{schema}}-{{table}}.*"),
+            fullExport = Some(false)
           )
         ),
         globalJdbcSchema = Some(
@@ -275,9 +276,9 @@ class ExtractSpec extends TestHelper {
           JDBCSchema(
             catalog = Some("business"),
             tables = List(
-              JDBCTable("user", List("id", "email"), None, None, Map.empty, None),
-              JDBCTable("product", Nil, None, None, Map.empty, None),
-              JDBCTable("*", Nil, None, None, Map.empty, None)
+              JDBCTable("user", List("id", "email"), None, None, Map.empty, None, None),
+              JDBCTable("product", Nil, None, None, Map.empty, None, None),
+              JDBCTable("*", Nil, None, None, Map.empty, None, None)
             ),
             tableTypes = List(
               "TABLE",
@@ -289,7 +290,8 @@ class ExtractSpec extends TestHelper {
               "SYNONYM"
             ),
             template = Some("/my-templates/domain-template.yml"),
-            pattern = Some("{{schema}}-{{table}}.*")
+            pattern = Some("{{schema}}-{{table}}.*"),
+            fullExport = Some(false)
           )
         ),
         globalJdbcSchema = Some(
@@ -333,7 +335,7 @@ class ExtractSpec extends TestHelper {
           "PUBLIC",
           None,
           None,
-          List(JDBCTable("TEST_TABLE1", List("ID"), None, None, Map.empty, None))
+          List(JDBCTable("TEST_TABLE1", List("ID"), None, None, Map.empty, None, None))
         ).fillWithDefaultValues(),
         settings.comet.connections("test-h2").options,
         File("/tmp"),
@@ -396,7 +398,7 @@ class ExtractSpec extends TestHelper {
           "PUBLIC",
           None,
           None,
-          List(JDBCTable("TEST_TABLE2", Nil, None, None, Map.empty, None))
+          List(JDBCTable("TEST_TABLE2", Nil, None, None, Map.empty, None, None))
         ).fillWithDefaultValues(),
         settings.comet.connections("test-h2").options,
         File("/tmp"),
@@ -445,6 +447,7 @@ class ExtractSpec extends TestHelper {
         |  --separator <value>      Column separator
         |  --clean                  Cleanup output directory first ?
         |  --output-dir <value>     Where to output csv files
+        |  --fullExport             Force full export to all tables
         |""".stripMargin
     rendered.substring(rendered.indexOf("Usage:")).replaceAll("\\s", "") shouldEqual expected
       .replaceAll("\\s", "")


### PR DESCRIPTION
__Feature__:
- allow full export for tables and use partition column only to speed up extraction
- allow to force full export. Useful for re-init cases.

__Bug Fix__:
- Use audit connection settings while fetching last export and its column quotes
- Division by zero when computing progress bar
- Human Readable throw exception when elapsed time is 0
- **Breaking Change** Make table's fetchSize to have higher precedence than the one defined in jdbcSchema.