### PR TITLE
fix: null timestamp when extracting last timestamp export.

### DIFF
--- a/src/main/scala/ai/starlake/extract/JDBCUtils.scala
+++ b/src/main/scala/ai/starlake/extract/JDBCUtils.scala
@@ -1450,7 +1450,7 @@ object LastExportUtils extends LazyLogging {
     preparedStatement.setString(2, schema)
     val rs = preparedStatement.executeQuery()
     if (rs.next()) {
-      Some(rs.getTimestamp(1))
+      Option(rs.getTimestamp(1))
     } else {
       None
     }


### PR DESCRIPTION
## Summary
fix null pointer when no entries found for a table in sl_last_export