### PR TITLE
fix: return accepted dataset instead of total dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Release notes
 
+# 0.7.3:
+
+__Bug Fix__:
+- report correct JSON accepted lines in audit
+
 # 0.7.2:
 __Feature__:
 - allow full export for tables and use partition column only to speed up extraction

--- a/src/main/scala/ai/starlake/job/ingest/JsonIngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/JsonIngestionJob.scala
@@ -161,7 +161,7 @@ class JsonIngestionJob(
 
     saveRejected(rejectedDS, validationResult.rejected)
     saveAccepted(validationResult) // prefer to let Spark compute the final schema
-    (rejectedDS, toValidate)
+    (rejectedDS, validationResult.accepted)
   }
 
   override def name: String = "JsonJob"


### PR DESCRIPTION
## Summary
return accepted dataset instead of total dataset in order to have accurated count accepted in audit log.

Closes #497 