### PR TITLE
- minimize data to fetch from bigquery

### DIFF
--- a/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
@@ -547,7 +547,7 @@ trait IngestionJob extends SparkJob {
   ): List[String] = {
     val detectImpliedPartitions =
       s"SELECT DISTINCT cast(date(`$partitionName`) as STRING) AS $partitionName FROM ($sql)"
-    bigqueryJob.runInteractiveQuery(Some(detectImpliedPartitions)) match {
+    bigqueryJob.runInteractiveQuery(Some(detectImpliedPartitions), pageSize = Some(1000)) match {
       case Failure(exception) => throw exception
       case Success(result) =>
         result.tableResult

--- a/src/main/scala/ai/starlake/job/transform/AutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/AutoTask.scala
@@ -57,7 +57,8 @@ object AutoTask extends StrictLogging {
   def task(
     taskDesc: AutoTaskDesc,
     configOptions: Map[String, String],
-    interactive: Option[String]
+    interactive: Option[String],
+    resultPageSize: Int = 1
   )(implicit
     settings: Settings,
     storageHandler: StorageHandler,
@@ -70,7 +71,8 @@ object AutoTask extends StrictLogging {
         .map(_.getSink())
         .orElse(Some(AllSinks().getSink())),
       interactive,
-      taskDesc.getDatabase()
+      taskDesc.getDatabase(),
+      resultPageSize = resultPageSize
     )
   }
 }
@@ -92,7 +94,8 @@ case class AutoTask(
   commandParameters: Map[String, String],
   sink: Option[Sink],
   interactive: Option[String],
-  database: Option[String]
+  database: Option[String],
+  resultPageSize: Int = 1
 )(implicit val settings: Settings, storageHandler: StorageHandler, schemaHandler: SchemaHandler)
     extends SparkJob {
   override def name: String = taskDesc.name
@@ -146,7 +149,7 @@ case class AutoTask(
           "(" + sql + ")"
         else
           sql
-      new BigQueryNativeJob(config, finalSql)
+      new BigQueryNativeJob(config, finalSql, this.resultPageSize)
     }
 
     val start = Timestamp.from(Instant.now())

--- a/src/main/scala/ai/starlake/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/ai/starlake/workflow/IngestionWorkflow.scala
@@ -702,7 +702,8 @@ class IngestionWorkflow(
     AutoTask.task(
       taskDesc,
       config.options,
-      config.interactive
+      config.interactive,
+      resultPageSize = 1000
     )(
       settings,
       storageHandler,


### PR DESCRIPTION
getQueryResults fetch all data. Add query page result options in order to minimize fetched data and avoid out of memory with cloud run jobs, improve performance.