### PR TITLE
feat: improve extract-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 __Improvement__:
   - Count null partition rows as rejected with dynamic partition overwrite
+  - **BREAKING CHANGE** Extract-schema sanitize domain name if sanitizeName is true. Have same value for domain name and its folder. By default sanitizaName is false.
+  - 'directory' is not mandatory in extract template
+  - load individual domain only in extract-schema
 
 # 0.8.0:
 - ** DEPRECATED **

--- a/src/main/scala/ai/starlake/extract/JDBCSchemas.scala
+++ b/src/main/scala/ai/starlake/extract/JDBCSchemas.scala
@@ -52,7 +52,8 @@ case class JDBCSchemas(
             fetchSize = schema.fetchSize.orElse(default.flatMap(_.fetchSize)),
             stringPartitionFunc =
               schema.stringPartitionFunc.orElse(default.flatMap(_.stringPartitionFunc)),
-            fullExport = schema.fullExport.orElse(default.flatMap(_.fullExport))
+            fullExport = schema.fullExport.orElse(default.flatMap(_.fullExport)),
+            sanitizeName = schema.sanitizeName.orElse(default.flatMap(_.sanitizeName))
           )
           .fillWithDefaultValues()
       }))
@@ -90,7 +91,8 @@ case class JDBCSchema(
   connectionOptions: Map[String, String] = Map.empty,
   fetchSize: Option[Int] = None,
   stringPartitionFunc: Option[String] = None,
-  fullExport: Option[Boolean] = None
+  fullExport: Option[Boolean] = None,
+  sanitizeName: Option[Boolean] = None
 ) {
   def this() = this(None) // Should never be called. Here for Jackson deserialization only
 
@@ -99,7 +101,8 @@ case class JDBCSchema(
   def fillWithDefaultValues(): JDBCSchema = {
     copy(
       tableTypes = if (tableTypes.isEmpty) JDBCSchema.defaultTableTypes else tableTypes,
-      fullExport = Some(false)
+      fullExport = if (fullExport.isEmpty) Some(false) else fullExport,
+      sanitizeName = if (sanitizeName.isEmpty) Some(false) else sanitizeName
     )
   }
 }

--- a/src/main/scala/ai/starlake/schema/generator/AclDependencies.scala
+++ b/src/main/scala/ai/starlake/schema/generator/AclDependencies.scala
@@ -20,7 +20,7 @@ class AclDependencies(schemaHandler: SchemaHandler) extends LazyLogging {
                      |""".stripMargin
 
   private def formatDotName(name: String) = {
-    name.replaceAll("[^\\p{Alnum}]", "_")
+    Utils.keepAlphaNum(name)
   }
 
   def run(args: Array[String]): Unit = {

--- a/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
@@ -460,9 +460,11 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
           (configPath, domainWithName)
 
         } else {
-          (configPath, Success(Domain(directory.getName())))
+          (
+            configPath,
+            Failure(new RuntimeException(s"Config file not found in ${directory.toString}"))
+          )
         }
-
       }
     val domains = domainsOnly.map { case (configPath, domainOnly) =>
       // grants list can be set a comma separated list in YAML , and transformed to a list while parsing
@@ -1083,7 +1085,7 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
     *   Unique Domain referenced by this name.
     */
   def getDomain(name: String, raw: Boolean = false): Option[Domain] =
-    domains(raw = raw).find(_.name == name)
+    domains(domainNames = List(name), raw = raw).find(_.name == name)
 
   /** Return all schemas for a domain
     *

--- a/src/test/scala/ai/starlake/extract/ExtractSpec.scala
+++ b/src/test/scala/ai/starlake/extract/ExtractSpec.scala
@@ -190,6 +190,8 @@ class ExtractSpec extends TestHelper {
           |      - "VIEW"
           |    template: "/my-templates/domain-template.yml" # Metadata to use for the generated YML file.
           |    pattern: "{{schema}}-{{table}}.*"
+          |    fullExport: true
+          |    sanitizeName: true
           |  jdbcSchemas:
           |    - tables:
           |        - name: "user"
@@ -222,7 +224,8 @@ class ExtractSpec extends TestHelper {
             ),
             template = Some("/my-templates/domain-template.yml"),
             pattern = Some("{{schema}}-{{table}}.*"),
-            fullExport = Some(false)
+            fullExport = Some(true),
+            sanitizeName = Some(true)
           )
         ),
         default = Some(
@@ -235,7 +238,9 @@ class ExtractSpec extends TestHelper {
               "VIEW"
             ),
             template = Some("/my-templates/domain-template.yml"),
-            pattern = Some("{{schema}}-{{table}}.*")
+            pattern = Some("{{schema}}-{{table}}.*"),
+            fullExport = Some(true),
+            sanitizeName = Some(true)
           )
         ),
         connection = Map.empty
@@ -289,7 +294,8 @@ class ExtractSpec extends TestHelper {
             ),
             template = Some("/my-templates/domain-template.yml"),
             pattern = Some("{{schema}}-{{table}}.*"),
-            fullExport = Some(false)
+            fullExport = Some(false),
+            sanitizeName = Some(false)
           )
         ),
         default = Some(


### PR DESCRIPTION
- **BREAKING CHANGE** Extract-schema sanitize domain name if sanitizeName is true. Have same value for domain name and its folder. By default sanitizeName is false.
  This makes it compatible with speed improvement during 'load' because the folder name could not match the domain name.
- 'directory' is not mandatory in extract template
- load individual domain only in extract-schema
- fix file scheme which throw an exception on windows