### PR TITLE
delete empty partitions after transformation using spark and BQ 

### DIFF
--- a/src/main/scala/ai/starlake/job/transform/SparkAutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/SparkAutoTask.scala
@@ -259,7 +259,9 @@ class SparkAutoTask(
                         .getOrElse(LocalDate.now())
                       val partitions: List[String] =
                         (for (i <- Range.inclusive(0, ChronoUnit.DAYS.between(start, end).toInt))
-                          yield start.plusDays(i).format(DateTimeFormatter.ISO_LOCAL_DATE)).toList
+                          yield start
+                            .plusDays(i)
+                            .format(DateTimeFormatter.ofPattern("yyyyMMdd"))).toList
                       Some(partitions)
                     case _ => None
                   }

--- a/src/main/scala/ai/starlake/schema/model/AutoTaskDesc.scala
+++ b/src/main/scala/ai/starlake/schema/model/AutoTaskDesc.scala
@@ -50,7 +50,9 @@ case class AutoTaskDesc(
   schedule: Option[String] = None,
   _filenamePrefix: String = "", // for internal use. prefix of sql / py file
   parseSQL: Option[Boolean] = None,
-  _auditTableName: Option[String] = None
+  _auditTableName: Option[String] = None,
+  startPartition: Option[String] = None,
+  endPartition: Option[String] = None
 ) extends Named {
 
   @JsonIgnore


### PR DESCRIPTION
## Summary
add 2 optional parameters startPartition, endPartition to AutoTask configuration in order to force the deletion of empty partitions after transformation using spark and BQ sink

**PR Type: Feature**

**Status: WIP**

**Breaking change? No**

