### PR TITLE
force any object serialized as string by the yaml serializer to be encoded in a specific charset (UTF-8 by default)

### DIFF
--- a/src/main/scala/ai/starlake/schema/ProjectCompare.scala
+++ b/src/main/scala/ai/starlake/schema/ProjectCompare.scala
@@ -1,6 +1,7 @@
 package ai.starlake.schema
 
 import ai.starlake.config.Settings
+import ai.starlake.schema.handlers.SchemaHandler
 import ai.starlake.schema.model.{Project, ProjectDiff}
 import org.apache.hadoop.fs.Path
 import org.fusesource.scalate.{TemplateEngine, TemplateSource}
@@ -8,14 +9,8 @@ import org.fusesource.scalate.{TemplateEngine, TemplateSource}
 import scala.util.Try
 
 object ProjectCompare {
-  def run(args: Array[String])(implicit settings: Settings): Try[Unit] = Try {
-    ProjectCompareConfig.parse(args) match {
-      case Some(config) =>
-        compare(config)
-      case None =>
-        throw new IllegalArgumentException(ProjectCompareConfig.usage())
-    }
-  }
+  def run(args: Array[String])(implicit settings: Settings): Try[Unit] =
+    ProjectCompareCmd.run(args, new SchemaHandler(settings.storageHandler())).map(_ => ())
 
   def compare(config: ProjectCompareConfig)(implicit settings: Settings): Unit = {
     val diff = Project.compare(config)

--- a/src/main/scala/ai/starlake/schema/ProjectCompareConfig.scala
+++ b/src/main/scala/ai/starlake/schema/ProjectCompareConfig.scala
@@ -1,44 +1,8 @@
 package ai.starlake.schema
 
-import ai.starlake.utils.CliConfig
-import scopt.OParser
-
 case class ProjectCompareConfig(
   project1: String = "",
   project2: String = "",
   template: Option[String] = None,
   output: Option[String] = None
 )
-
-object ProjectCompareConfig extends CliConfig[ProjectCompareConfig] {
-  val command = "compare"
-
-  val parser: OParser[Unit, ProjectCompareConfig] = {
-    val builder = OParser.builder[ProjectCompareConfig]
-    import builder._
-    OParser.sequence(
-      programName(s"starlake $command"),
-      head("starlake", command, "[options]"),
-      note(""),
-      opt[String]("project1")
-        .action { (x, c) => c.copy(project1 = x) }
-        .required()
-        .text("old project metadata path"),
-      opt[String]("project2")
-        .action { (x, c) => c.copy(project2 = x) }
-        .required()
-        .text("new project metadata path"),
-      opt[String]("template")
-        .action { (x, c) => c.copy(template = Some(x)) }
-        .optional()
-        .text("SSP / Mustache Template path"),
-      opt[String]("output")
-        .action { (x, c) => c.copy(output = Some(x)) }
-        .optional()
-        .text("Output path")
-    )
-  }
-
-  def parse(args: Seq[String]): Option[ProjectCompareConfig] =
-    OParser.parse(parser, args, ProjectCompareConfig(), setup)
-}

--- a/src/main/scala/ai/starlake/schema/generator/Xls2YmlAutoJob.scala
+++ b/src/main/scala/ai/starlake/schema/generator/Xls2YmlAutoJob.scala
@@ -21,22 +21,22 @@ object Xls2YmlAutoJob extends LazyLogging {
     val basePath = outputPath.getOrElse(DatasetArea.transform.toString)
     val reader = new XlsAutoJobReader(InputPath(inputPath), policyPath.map(InputPath))
     reader.autoTasksDesc
-      .foreach { autotask =>
-        val taskPath = File(basePath, autotask.domain)
-        logger.info(s"Generating autoJob schema for ${autotask.name} in $taskPath")
+      .foreach { autoTask =>
+        val taskPath = File(basePath, autoTask.domain)
+        logger.info(s"Generating autoJob schema for ${autoTask.name} in $taskPath")
         writeAutoTaskYaml(
-          autotask,
+          autoTask,
           taskPath,
-          autotask.name
+          autoTask.name
         )
       }
   }
 
-  def writeAutoTaskYaml(autotask: AutoTaskDesc, outputPath: File, fileName: String): Unit = {
+  def writeAutoTaskYaml(autoTask: AutoTaskDesc, outputPath: File, fileName: String): Unit = {
     outputPath.createIfNotExists(asDirectory = true, createParents = true)
     logger.info(s"""Generated autoJob schemas:
-                   |${serialize(autotask)}""".stripMargin)
-    serializeToFile(File(outputPath, s"$fileName.sl.yml"), autotask)
+                   |${serialize(autoTask)}""".stripMargin)
+    serializeToFile(File(outputPath, s"$fileName.sl.yml"), autoTask)
   }
 
   def run(args: Array[String]): Try[Unit] = {

--- a/src/main/scala/ai/starlake/utils/Utils.scala
+++ b/src/main/scala/ai/starlake/utils/Utils.scala
@@ -256,7 +256,7 @@ object Utils extends StrictLogging {
     }.toMap
 
   def jinjava(implicit settings: Settings): Jinjava = {
-    if (_jinjava.isEmpty) {
+    if (_jinjava == null) {
       val curClassLoader = Thread.currentThread.getContextClassLoader
       val res =
         try {
@@ -264,15 +264,15 @@ object Utils extends StrictLogging {
           new Jinjava()
         } finally Thread.currentThread.setContextClassLoader(curClassLoader)
       res.setResourceLocator(new JinjaResourceHandler())
-      _jinjava = Some(res)
+      _jinjava = res
     }
-    _jinjava.get
+    _jinjava
   }
 
-  private var _jinjava: Option[Jinjava] = None
+  private var _jinjava: Jinjava = null
 
   def resetJinjaClassLoader(): Unit = {
-    _jinjava = None
+    _jinjava = null
   }
 
   def parseJinja(str: String, params: Map[String, Any])(implicit settings: Settings): String =

--- a/src/main/scala/ai/starlake/utils/YamlSerializer.scala
+++ b/src/main/scala/ai/starlake/utils/YamlSerializer.scala
@@ -28,12 +28,13 @@ import scala.util.{Failure, Success, Try}
 object YamlSerializer extends LazyLogging {
   val mapper: ObjectMapper = Utils.newYamlMapper()
 
-  private def serializeAsString(
-    value: Any,
-    charset: Charset = sun.nio.cs.UTF_8.INSTANCE
-  ): String = {
+  val charset: Charset = sun.nio.cs.UTF_8.INSTANCE
+
+  private lazy val differentCharsets: Boolean = Charset.defaultCharset() != charset
+
+  private def serializeAsString(value: Any): String = {
     val string = mapper.writeValueAsString(value)
-    if (Charset.defaultCharset() != charset)
+    if (differentCharsets)
       new String(
         string.getBytes(charset),
         charset

--- a/src/main/scala/ai/starlake/utils/YamlSerializer.scala
+++ b/src/main/scala/ai/starlake/utils/YamlSerializer.scala
@@ -18,33 +18,47 @@ import ai.starlake.schema.model.{
 import better.files.File
 import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode, TextNode}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.fs.Path
 
+import java.nio.charset.Charset
 import scala.jdk.CollectionConverters.asScalaBufferConverter
 import scala.util.{Failure, Success, Try}
 
 object YamlSerializer extends LazyLogging {
-  val mapper: ObjectMapper = new ObjectMapper(new YAMLFactory())
-  Utils.setMapperProperties(mapper)
+  val mapper: ObjectMapper = Utils.newYamlMapper()
 
-  def serialize(domain: Domain): String = mapper.writeValueAsString(domain)
+  private def serializeAsString(
+    value: Any,
+    charset: Charset = sun.nio.cs.UTF_8.INSTANCE
+  ): String = {
+    val string = mapper.writeValueAsString(value)
+    if (Charset.defaultCharset() != charset)
+      new String(
+        string.getBytes(charset),
+        charset
+      )
+    else {
+      string
+    }
+  }
 
-  def serialize(iamPolicyTags: IamPolicyTags): String = mapper.writeValueAsString(iamPolicyTags)
+  def serialize(domain: Domain): String = serializeAsString(domain)
+
+  def serialize(iamPolicyTags: IamPolicyTags): String = serializeAsString(iamPolicyTags)
 
   def deserializeIamPolicyTags(content: String): IamPolicyTags = {
     val rootNode = mapper.readTree(content)
     mapper.treeToValue(rootNode, classOf[IamPolicyTags])
   }
 
-  def serialize(autoJob: AutoJobDesc): String = mapper.writeValueAsString(autoJob)
+  def serialize(autoJob: AutoJobDesc): String = serializeAsString(autoJob)
 
-  def serialize(autoTask: AutoTaskDesc): String = mapper.writeValueAsString(autoTask)
+  def serialize(autoTask: AutoTaskDesc): String = serializeAsString(autoTask)
 
-  def serialize(schema: ModelSchema): String = mapper.writeValueAsString(schema)
+  def serialize(schema: ModelSchema): String = serializeAsString(schema)
 
-  def serializeObject(obj: Object): String = mapper.writeValueAsString(obj)
+  def serializeObject(obj: Object): String = serializeAsString(obj)
 
   def toMap(job: AutoJobDesc)(implicit settings: Settings): Map[String, Any] = {
     val jobWriter = mapper
@@ -55,16 +69,16 @@ object YamlSerializer extends LazyLogging {
     mapper.readValue(jsonContent, classOf[Map[String, Any]])
   }
 
-  def serialize(jdbcSchemas: JDBCSchemas): String = mapper.writeValueAsString(jdbcSchemas)
-  def serialize(schemas: SchemaRefs): String = mapper.writeValueAsString(schemas)
+  def serialize(jdbcSchemas: JDBCSchemas): String = serializeAsString(jdbcSchemas)
+  def serialize(schemas: SchemaRefs): String = serializeAsString(schemas)
 
   def deserializeJDBCSchemas(content: String, inputFilename: String): JDBCSchemas = {
     val rootNode = mapper.readTree(content)
     val extractNode = rootNode.path("extract")
     val jdbcNode =
-      if (extractNode.isNull() || extractNode.isMissingNode) {
+      if (extractNode.isNull || extractNode.isMissingNode) {
         logger.warn(
-          s"Defining a jdbc schema outside an extract node is now deprecated. Please update definition ${inputFilename}"
+          s"Defining a jdbc schema outside an extract node is now deprecated. Please update definition $inputFilename"
         )
         rootNode
       } else
@@ -103,7 +117,7 @@ object YamlSerializer extends LazyLogging {
   }
 
   def serializeDomain(domain: Domain): String = {
-    mapper.writeValueAsString(LoadDesc(domain))
+    serializeAsString(LoadDesc(domain))
   }
 
   def serializeToFile(targetFile: File, domain: Domain): Unit = {
@@ -128,7 +142,7 @@ object YamlSerializer extends LazyLogging {
 
   def serializeTable(schema: ModelSchema): String = {
     case class Table(table: ModelSchema)
-    mapper.writeValueAsString(Table(schema))
+    serializeAsString(Table(schema))
   }
 
   def serializeToFile(targetFile: File, iamPolicyTags: IamPolicyTags): Unit = {
@@ -164,7 +178,7 @@ object YamlSerializer extends LazyLogging {
       val rootNode = mapper.readTree(content)
       val loadNode = rootNode.path("load")
       val domainNode =
-        if (loadNode.isNull() || loadNode.isMissingNode) {
+        if (loadNode.isNull || loadNode.isMissingNode) {
           rootNode.asInstanceOf[ObjectNode]
         } else
           loadNode.asInstanceOf[ObjectNode]
@@ -204,7 +218,7 @@ object YamlSerializer extends LazyLogging {
     Try {
       val rootNode = mapper.readTree(content)
       val dagNode = rootNode.path("dag")
-      if (dagNode.isNull() || dagNode.isMissingNode) {
+      if (dagNode.isNull || dagNode.isMissingNode) {
         throw new RuntimeException(
           s"No 'dag' attribute found in $path. Please define your dag generation config under 'dag' attribute."
         )
@@ -223,7 +237,7 @@ object YamlSerializer extends LazyLogging {
     val rootNode = mapper.readTree(content)
     val taskNode = rootNode.path("task")
     val targetNode =
-      if (taskNode.isNull() || taskNode.isMissingNode) {
+      if (taskNode.isNull || taskNode.isMissingNode) {
         rootNode.asInstanceOf[ObjectNode]
       } else
         taskNode.asInstanceOf[ObjectNode]
@@ -260,7 +274,7 @@ object YamlSerializer extends LazyLogging {
       val rootNode = mapper.readTree(content)
       val transformNode = rootNode.path("transform")
       val jobNode =
-        if (transformNode.isNull() || transformNode.isMissingNode) {
+        if (transformNode.isNull || transformNode.isMissingNode) {
           rootNode.asInstanceOf[ObjectNode]
         } else
           transformNode.asInstanceOf[ObjectNode]


### PR DESCRIPTION
## Summary
force any object serialized as string by the yaml serializer to be encoded in a specific charset (UTF-8 by default)

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [  ] I have updated the Release notes.
- [  ] My change requires a change to the documentation.
- [  ] I have updated the documentation accordingly.



