### PR TITLE
fix: table's metadata merge during schema extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ __Bug Fix__:
 - Throw expected exception when no connection ref found.
 - turn missing additional columns optional on native bigquery csv data ingestion
 - fix quote on data extraction when no partition is given. Failure occurs when query don't quote with '"'
+- table's metadata merge during schema extraction now takes `sink`, `ignore` and `directory` attribute into account.
 
 __Improvement__:
 - added `auditConnectionRef` to jdbc extract schemas to be on pair with connectionRef behavior

--- a/src/main/scala/ai/starlake/schema/model/Metadata.scala
+++ b/src/main/scala/ai/starlake/schema/model/Metadata.scala
@@ -343,6 +343,7 @@ case class Metadata(
     if (
       mode.nonEmpty || format.nonEmpty || encoding.nonEmpty || multiline.nonEmpty || array.nonEmpty ||
       withHeader.nonEmpty || separator.nonEmpty || quote.nonEmpty || escape.nonEmpty || write.nonEmpty ||
+      sink.nonEmpty || ignore.nonEmpty || directory.nonEmpty ||
       ack.nonEmpty || options.nonEmpty || loader.nonEmpty || dagRef.nonEmpty ||
       freshness.nonEmpty || nullValue.nonEmpty || emptyIsNull.nonEmpty
     )


### PR DESCRIPTION
fix table's metadata merge during schema extraction