### PR TITLE
feat: load gzip compressed files (.gz extension) into bigquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ __Improvement__:
 __Feature__:
 
 - generic templating framework for dag generation through the definition of a python library for starlake jobs
+- load gzip compressed files (.gz extension) into bigquery
 
 # 1.0.0:
 - **BREAKING CHANGE**


### PR DESCRIPTION
load gzip compressed files into bigquery.

Tested from local only.

IMO, would be great to remove LocalStorageHandler, is it still usefill to keep it ?