### PR TITLE
fix: use default load format during native ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ __Improvement__:
   - load individual domain only in extract-schema
 
 __Bug Fix__:
-- Data extraction retrieve last extraction date time but didn't get the right one for partitionned tables.  
+- Data extraction retrieve last extraction date time but didn't get the right one for partitionned tables.
+- Use default load format during native ingestion
 
 # 0.8.0:
 - ** DEPRECATED **

--- a/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/IngestionJob.scala
@@ -467,7 +467,7 @@ trait IngestionJob extends SparkJob {
           database = schemaHandler.getDatabase(domain),
           domain = domain.finalName,
           table = schema.finalName,
-          write = mergedMetadata.write,
+          write = Some(mergedMetadata.getWrite()),
           sink = mergedMetadata.sink,
           acl = schema.acl,
           comment = schema.comment,
@@ -765,8 +765,8 @@ trait IngestionJob extends SparkJob {
   }
 
   private def computeEffectiveInputSchema(): Schema = {
-    mergedMetadata.format match {
-      case Some(Format.DSV) =>
+    mergedMetadata.getFormat() match {
+      case Format.DSV =>
         (mergedMetadata.isWithHeader(), path.map(_.toString).headOption) match {
           case (java.lang.Boolean.TRUE, Some(sourceFile)) =>
             val csvHeaders = storageHandler.readAndExecute(

--- a/src/main/scala/ai/starlake/job/ingest/KafkaIngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/KafkaIngestionJob.scala
@@ -66,15 +66,15 @@ class KafkaIngestionJob(
     *   Spark DataFrame where each row holds a single string
     */
   override protected def loadJsonData(): Dataset[String] = {
-    val dfIn = mergedMetadata.mode match {
-      case None | Some(Mode.FILE) =>
+    val dfIn = mergedMetadata.getMode() match {
+      case Mode.FILE =>
         Utils.withResources(new KafkaClient(settings.appConfig.kafka)) { kafkaClient =>
           val (dfIn, offsets) =
             kafkaClient.consumeTopicBatch(schema.name, session, topicConfig)
           this.offsets = offsets
           dfIn
         }
-      case Some(Mode.STREAM) =>
+      case Mode.STREAM =>
         Utils.withResources(new KafkaClient(settings.appConfig.kafka)) { kafkaClient =>
           KafkaClient.consumeTopicStreaming(session, topicConfig)
         }

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
@@ -224,11 +224,7 @@ class BigQueryNativeJob(
               CsvOptions.newBuilder.setAllowQuotedNewLines(true).setAllowJaggedRows(true)
             if (metadata.isWithHeader())
               formatOptions.setSkipLeadingRows(1).build
-            metadata.encoding match {
-              case Some(encoding) =>
-                formatOptions.setEncoding(encoding)
-              case None =>
-            }
+            formatOptions.setEncoding(metadata.getEncoding())
             formatOptions.setFieldDelimiter(metadata.getSeparator())
             metadata.quote.map(quote => formatOptions.setQuote(quote))
             formatOptions.setAllowJaggedRows(true)

--- a/src/main/scala/ai/starlake/schema/model/Metadata.scala
+++ b/src/main/scala/ai/starlake/schema/model/Metadata.scala
@@ -148,16 +148,16 @@ case class Metadata(
        |separator:${getSeparator()}
        |quote:${getQuote()}
        |escape:${getEscape()}
-       |write:${write}
+       |write:${getWrite()}
        |sink:${sink}
        |directory:${directory}
        |extensions:${extensions}
        |ack:${ack}
-       |options:${options}
+       |options:${getOptions()}
        |loader:${loader}
        |dag:${dagRef}
        |freshness:${freshness}
-       |nullValue:${nullValue}
+       |nullValue:${getNullValue()}
        |emptyIsNull:${emptyIsNull}
        |dag:$dagRef
        |fillWithDefaultValue:$fillWithDefaultValue""".stripMargin
@@ -184,7 +184,7 @@ case class Metadata(
 
   def getEscape(): String = getFinalValue(escape, "\\")
 
-  def getWrite()(implicit settings: Settings): WriteMode =
+  def getWrite(): WriteMode =
     getFinalValue(write, APPEND)
 
   @JsonIgnore


### PR DESCRIPTION
use getters when possible instead of the attribute directly.
Side effect of not using getters during native load is that columns are not ordered correctly. If changes happen regarding CSV columns, then, without explicitly specifying format metadata, column's order follows starlake schema only.