### PR TITLE
Downgrade to bigquery 2.36.0

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -18,7 +18,7 @@ object Versions {
   val esSpark212 = "8.10.3"
   val scopt = "4.1.0"
   val gcsConnector = "hadoop3-2.2.19"
-  val bigquery = "2.37.0"
+  val bigquery = "2.36.0"
   val hadoop = "3.3.6"
   val sparkBigqueryWithDependencies = "0.36.0"
   val bigqueryConnector = "hadoop3-1.2.0"


### PR DESCRIPTION
## Summary
After the scala steward upgrade of bigquery lib version, we have an error on the starlake api ""java.lang.String com.google.auth.Credentials.getUniverseDomain()"


**Related Issue: #IssueId**

**PR Type: Bug Fix **

**Status:Ready to review**

**Breaking change? No**

