### PR TITLE
fix: Align infered schema primitive's type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ __Bug Fix__:
 - Mysql extraction could fetch wrong table's information
 - Data extraction fresh enough was done on any success state, it now only consider successful extractions
 - Align infered schema primitive's type with the one declared `types.sl.yml`.
+- Fix dockerfile for latest Alpine by adding bash package
 
 __Improvement__:
 - added `auditConnectionRef` to jdbc extract schemas to be on pair with connectionRef behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ __Bug Fix__:
 - Use default load format during native ingestion
 - Mysql extraction could fetch wrong table's information
 - Data extraction fresh enough was done on any success state, it now only consider successful extractions
+- Align infered schema primitive's type with the one declared `types.sl.yml`.
 
 __Improvement__:
 - added `auditConnectionRef` to jdbc extract schemas to be on pair with connectionRef behavior

--- a/src/main/scala/ai/starlake/utils/SparkUtils.scala
+++ b/src/main/scala/ai/starlake/utils/SparkUtils.scala
@@ -127,7 +127,7 @@ object SparkUtils extends StrictLogging {
     val reworkedUrl =
       url.replace("jdbc:redshift", "jdbc:postgresql").replace("jdbc:as400", "jdbc:db2")
     val jdbcDialect = JdbcDialects.get(reworkedUrl)
-    logger.info(s"JDBC dialect $jdbcDialect")
+    logger.debug(s"JDBC dialect $jdbcDialect")
     jdbcDialect
   }
 

--- a/src/test/scala/ai/starlake/schema/handlers/InferSchemaHandlerSpec.scala
+++ b/src/test/scala/ai/starlake/schema/handlers/InferSchemaHandlerSpec.scala
@@ -126,7 +126,7 @@ class InferSchemaHandlerSpec extends TestHelper {
       val dsv1: List[Attribute] = List(
         Attribute("_c0", "string", Some(false), required = false),
         Attribute("_c1", "string", Some(false), required = false),
-        Attribute("_c2", "integer", Some(false), required = false)
+        Attribute("_c2", "int", Some(false), required = false)
       )
       dsv shouldBe dsv1
 


### PR DESCRIPTION
Align infered schema primitive's type with the one declared `types.sl.yml`.

For instance int was infered as integer primitive type. Making it impossible to ingest the files by default because this primitive type doesn't exist.