### PR TITLE
feat: add hash or timestamp to snapshot version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Release notes
 
+# 1.1.1:
+__Improvement__:
+- add git hash or timestamp if no git info to printed SNAPSHOT version. Requires SBT reload to get new settings.
+
 # 1.1.0:
 **BREAKING CHANGE** 
 - Data extraction didn't fail on table's extraction failure. In order to keep behaviour, use `--ignoreExtractionFailure`

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -25,7 +25,11 @@ import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
 import sbt.Keys._
 import sbt.{Def, _}
 import sbtassembly.AssemblyKeys._
-import sbtbuildinfo.BuildInfoPlugin
+import sbtbuildinfo.{BuildInfoKey, BuildInfoPlugin}
+import sbtbuildinfo.BuildInfoPlugin.autoImport.buildInfoKeys
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 object Common {
 
@@ -86,7 +90,20 @@ object Common {
         Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
       ),
       Test / parallelExecution := false,
-      scalafmtOnCompile := true
+      scalafmtOnCompile := true,
+      buildInfoKeys := Seq[BuildInfoKey](name, scalaVersion, sbtVersion),
+      buildInfoKeys ++= Seq[BuildInfoKey](
+        BuildInfoKey.action("version") {
+          val currentVersion = version.value
+          if (currentVersion.contains("-SNAPSHOT")) {
+            val suffix = git.gitHeadCommit.value
+              .map(_.take(8))
+              .getOrElse("T" + ZonedDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME))
+            // val suffix = "T" + ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+            currentVersion + " @ " + suffix
+          } else currentVersion
+        }
+      )
     ) ++ gitSettings ++ assemlySettings
 
 }

--- a/src/test/scala/ai/starlake/extract/ExtractSpec.scala
+++ b/src/test/scala/ai/starlake/extract/ExtractSpec.scala
@@ -92,7 +92,7 @@ class ExtractSpec extends TestHelper {
       }
     assert(domain.name == "PUBLIC")
 
-    val tableFile = publicOutputDir / "TEST_TABLE1.sl.yml"
+    val tableFile = publicOutputDir / "test_table1.sl.yml"
     val table =
       YamlSerializer
         .deserializeSchemaRefs(tableFile.contentAsString, tableFile.pathAsString)
@@ -104,7 +104,7 @@ class ExtractSpec extends TestHelper {
     )
     table.primaryKey should contain("id")
     table.pattern.pattern() shouldBe "\\QPUBLIC\\E-\\Qtest_table1\\E.*"
-    val viewFile = publicOutputDir / "TEST_VIEW1.sl.yml"
+    val viewFile = publicOutputDir / "test_view1.sl.yml"
     val view =
       YamlSerializer
         .deserializeSchemaRefs(viewFile.contentAsString, viewFile.pathAsString)
@@ -389,7 +389,7 @@ class ExtractSpec extends TestHelper {
           case Failure(e)      => throw e
         }
       assert(domain.name == "PUBLIC")
-      val tableFile = tmpDir / "PUBLIC" / "TEST_TABLE1.sl.yml"
+      val tableFile = tmpDir / "PUBLIC" / "test_table1.sl.yml"
       val table =
         YamlSerializer
           .deserializeSchemaRefs(tableFile.contentAsString, tableFile.pathAsString)
@@ -451,7 +451,7 @@ class ExtractSpec extends TestHelper {
           case Failure(e)      => throw e
         }
       assert(domain.name == "PUBLIC")
-      val tableFile = File(tmpDir / "PUBLIC", "TEST_TABLE2.sl.yml")
+      val tableFile = File(tmpDir / "PUBLIC", "test_table2.sl.yml")
       val table =
         YamlSerializer
           .deserializeSchemaRefs(tableFile.contentAsString, tableFile.pathAsString)


### PR DESCRIPTION
add additional information for SNAPSHOT version during runtime in order to know more precisely which version we are running while deploying a SNAPSHOT.