### PR TITLE
take into account optional cron within datasets

### DIFF
--- a/src/main/python/starlake-airflow/ai/starlake/airflow/gcp/starlake_airflow_dataproc_job.py
+++ b/src/main/python/starlake-airflow/ai/starlake/airflow/gcp/starlake_airflow_dataproc_job.py
@@ -64,11 +64,11 @@ class StarlakeAirflowDataprocCluster(StarlakeAirflowOptions):
         self.cluster_config = StarlakeAirflowDataprocClusterConfig(
             cluster_id=None,
             dataproc_name=None,
-            master_config=None, 
-            worker_config=None, 
-            secondary_worker_config=None, 
-            idle_delete_ttl=None, 
-            single_node=None, 
+            master_config=None,
+            worker_config=None,
+            secondary_worker_config=None,
+            idle_delete_ttl=None,
+            single_node=None,
             options=self.options,
             **kwargs
         ) if not cluster_config else cluster_config
@@ -76,17 +76,19 @@ class StarlakeAirflowDataprocCluster(StarlakeAirflowOptions):
         self.pool = pool
 
     def create_dataproc_cluster(
-        self,
-        cluster_id: str=None,
-        task_id: str=None,
-        cluster_name: str=None,
-        **kwargs) -> BaseOperator:
+            self,
+            cluster_id: str=None,
+            task_id: str=None,
+            cluster_name: str=None,
+            **kwargs) -> BaseOperator:
         """
         Create the Cloud Dataproc cluster.
         This operator will be flagged a success if the cluster by this name already exists.
         """
         cluster_id = self.cluster_config.cluster_id if not cluster_id else cluster_id
-        cluster_name = f"{self.cluster_config.dataproc_name}-{cluster_id.replace('_', '-')}-{TODAY}" if not cluster_name else cluster_name
+        cluster_name = f"{self.cluster_config.dataproc_name}-{cluster_id.replace('_', '-')}-{TODAY}"[0:51] if not cluster_name else cluster_name[0:51]
+        if cluster_name[-1] == '-':
+            cluster_name = cluster_name[0:-1] + 'Z'
         task_id = f"create_{cluster_id.replace('-', '_')}_cluster" if not task_id else task_id
 
         kwargs.update({
@@ -101,23 +103,25 @@ class StarlakeAirflowDataprocCluster(StarlakeAirflowOptions):
             project_id=self.cluster_config.project_id,
             cluster_name=cluster_name,
             cluster_config=self.cluster_config.__config__(**{
-                    "dataproc:job.history.to-gcs.enabled": "true",
-                    "spark:spark.history.fs.logDirectory": f"gs://{spark_events_bucket}/tmp/spark-events/{{{{ds}}}}",
-                    "spark:spark.eventLog.dir": f"gs://{spark_events_bucket}/tmp/spark-events/{{{{ds}}}}",
+                "dataproc:job.history.to-gcs.enabled": "true",
+                "spark:spark.history.fs.logDirectory": f"gs://{spark_events_bucket}/tmp/spark-events/{{{{ds}}}}",
+                "spark:spark.eventLog.dir": f"gs://{spark_events_bucket}/tmp/spark-events/{{{{ds}}}}",
             }),
             region=self.cluster_config.region,
             **kwargs
         )
 
     def delete_dataproc_cluster(
-        self,
-        cluster_id: str=None,
-        task_id: str=None,
-        cluster_name: str=None,
-        **kwargs) -> BaseOperator:
+            self,
+            cluster_id: str=None,
+            task_id: str=None,
+            cluster_name: str=None,
+            **kwargs) -> BaseOperator:
         """Tears down the cluster even if there are failures in upstream tasks."""
         cluster_id = self.cluster_config.cluster_id if not cluster_id else cluster_id
-        cluster_name = f"{self.cluster_config.dataproc_name}-{cluster_id.replace('_', '-')}-{TODAY}" if not cluster_name else cluster_name
+        cluster_name = f"{self.cluster_config.dataproc_name}-{cluster_id.replace('_', '-')}-{TODAY}"[0:51] if not cluster_name else cluster_name[0:51]
+        if cluster_name[-1] == '-':
+            cluster_name = cluster_name[0:-1] + 'Z'
         task_id = f"delete_{cluster_id.replace('-', '_')}_cluster" if not task_id else task_id
         kwargs.update({
             'pool': kwargs.get('pool', self.pool),
@@ -143,7 +147,9 @@ class StarlakeAirflowDataprocCluster(StarlakeAirflowOptions):
         **kwargs) -> BaseOperator:
         """Create a dataproc job on the specified cluster"""
         cluster_id = self.cluster_config.cluster_id if not cluster_id else cluster_id
-        cluster_name = f"{self.cluster_config.dataproc_name}-{cluster_id.replace('_', '-')}-{TODAY}" if not cluster_name else cluster_name
+        cluster_name = f"{self.cluster_config.dataproc_name}-{cluster_id.replace('_', '-')}-{TODAY}"[0:51] if not cluster_name else cluster_name[0:51]
+        if cluster_name[-1] == '-':
+            cluster_name = cluster_name[0:-1] + 'Z'
         task_id = f"{cluster_id}_submit" if not task_id else task_id
         arguments = [] if not arguments else arguments
         jar_list = __class__.get_context_var(var_name="spark_jar_list", options=self.options).split(",") if not jar_list else jar_list

--- a/src/main/python/starlake-airflow/setup.py
+++ b/src/main/python/starlake-airflow/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='starlake-airflow',
-      version='0.1.2.1',
+      version='0.1.2.2',
       description='Starlake Python Distribution For Airflow',
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/src/main/resources/templates/dags/__common_airflow.py.j2
+++ b/src/main/resources/templates/dags/__common_airflow.py.j2
@@ -22,3 +22,23 @@ def default_spark_config(*args, **kwargs) -> StarlakeSparkConfig:
         **kwargs
     )
 spark_config = getattr(sys.modules[__name__], "get_spark_config", default_spark_config)
+
+from urllib import parse
+
+def asQueryParameters(parameters: dict = {}):
+    if parameters.__len__() > 0 :
+        return '?' + '&'.join(list(f'{parse.quote(k)}={parse.quote(v)}' for (k,v) in parameters.items()))
+    else :
+        return ''
+
+from croniter import croniter
+from datetime import datetime as dt
+
+def cron_start_time() -> dt:
+    return dt.fromtimestamp(dt.now().timestamp())
+
+sl_schedule_format = '%Y%m%dT%H%M'
+
+def sl_schedule(cron: str, start_time: dt = cron_start_time(), format: str = sl_schedule_format) -> str:
+  return croniter(cron, start_time).get_prev(dt).strftime(format)
+

--- a/src/main/resources/templates/dags/load/__airflow_scheduled_table_tpl.py.j2
+++ b/src/main/resources/templates/dags/load/__airflow_scheduled_table_tpl.py.j2
@@ -33,19 +33,16 @@ def generate_dag_name(schedule):
     dag_name = os.path.basename(__file__).replace(".py", "").replace(".pyc", "").lower()
     return (f"{dag_name}-{schedule['schedule']}" if len(schedules) > 1 else dag_name)
 
-_extra_dataset: Union[dict, None] = sys.modules[__name__].__dict__.get('extra_dataset', None)
-
-from urllib import parse
-
-_extra_dataset_parameters = '?' + '&'.join(list(f'{parse.quote(k)}={parse.quote(v)}' for (k,v) in _extra_dataset.items())) if _extra_dataset else ''
+_extra_dataset: dict = sys.modules[__name__].__dict__.get('extra_dataset', dict())
 
 # [START instantiate_dag]
 for schedule in schedules:
     tags = sl_job.get_context_var(var_name='tags', default_value="", options=options).split()
     for domain in schedule["domains"]:
         tags.append(domain["name"])
+    _cron = schedule['cron']
     with DAG(dag_id=generate_dag_name(schedule),
-             schedule_interval=schedule['cron'],
+             schedule=_cron,
              default_args=sys.modules[__name__].__dict__.get('default_dag_args', DEFAULT_DAG_ARGS),
              catchup=False,
              tags=set([tag.upper() for tag in tags]),
@@ -77,8 +74,11 @@ for schedule in schedules:
             start >> all_load_tasks
 
         extra: dict = {"source": dag.dag_id}
+        parameters = dict(_extra_dataset)
+        if _cron is not None :
+          parameters['sl_schedule'] = sl_schedule(_cron)
 
-        end = sl_job.dummy_op(task_id="end", outlets=[Dataset(keep_ascii_only(dag.dag_id), extra)]+list(map(lambda x: Dataset(x.uri + _extra_dataset_parameters, extra), sl_job.outlets)))
+        end = sl_job.dummy_op(task_id="end", outlets=[Dataset(keep_ascii_only(dag.dag_id), extra)]+list(map(lambda x: Dataset(x.uri + asQueryParameters(parameters), extra), sl_job.outlets)))
 
         all_load_tasks >> end
 

--- a/src/main/resources/templates/dags/load/__airflow_scheduled_table_tpl.py.j2
+++ b/src/main/resources/templates/dags/load/__airflow_scheduled_table_tpl.py.j2
@@ -35,7 +35,9 @@ def generate_dag_name(schedule):
 
 _extra_dataset: Union[dict, None] = sys.modules[__name__].__dict__.get('extra_dataset', None)
 
-_extra_dataset_parameters = '?' + '&'.join(list(f'{k}={v}' for (k,v) in _extra_dataset.items())) if _extra_dataset else ''
+from urllib import parse
+
+_extra_dataset_parameters = '?' + '&'.join(list(f'{parse.quote(k)}={parse.quote(v)}' for (k,v) in _extra_dataset.items())) if _extra_dataset else ''
 
 # [START instantiate_dag]
 for schedule in schedules:
@@ -74,7 +76,9 @@ for schedule in schedules:
         else:
             start >> all_load_tasks
 
-        end = sl_job.dummy_op(task_id="end", outlets=[Dataset(keep_ascii_only(dag.dag_id))]+list(map(lambda x: Dataset(x.uri + _extra_dataset_parameters), sl_job.outlets)))
+        extra: dict = {"source": dag.dag_id}
+
+        end = sl_job.dummy_op(task_id="end", outlets=[Dataset(keep_ascii_only(dag.dag_id), extra)]+list(map(lambda x: Dataset(x.uri + _extra_dataset_parameters, extra), sl_job.outlets)))
 
         all_load_tasks >> end
 

--- a/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
@@ -23,6 +23,8 @@ schedule = None
 
 datasets: Set[str] = []
 
+_filtered_datasets: Set[str] = sys.modules[__name__].__dict__.get('filtered_datasets', [])
+
 _extra_dataset: Union[dict, None] = sys.modules[__name__].__dict__.get('extra_dataset', None)
 
 _extra_dataset_parameters = '?' + '&'.join(list(f'{k}={v}' for (k,v) in _extra_dataset.items())) if _extra_dataset else ''
@@ -30,7 +32,9 @@ _extra_dataset_parameters = '?' + '&'.join(list(f'{k}={v}' for (k,v) in _extra_d
 def _load_datasets(task: dict):
     if 'children' in task:
         for child in task['children']:
-            datasets.append(keep_ascii_only(child['data']['name']).lower())
+            dataset = keep_ascii_only(child['data']['name']).lower()
+            if dataset not in _filtered_datasets:
+                datasets.append(dataset)
             _load_datasets(child)
 
 if load_dependencies.lower() != 'true':

--- a/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
@@ -15,38 +15,51 @@ from airflow.utils.task_group import TaskGroup
 
 cron = "{{ context.cron }}"
 
+_cron = None if cron == "None" else cron
+
 task_deps=json.loads("""{{ context.dependencies }}""")
 
 load_dependencies = sl_job.get_context_var(var_name='load_dependencies', default_value='False', options=options)
 
 schedule = None
 
-datasets: Set[str] = []
+datasets: Set[str] = set()
+
+cronDatasets: dict = dict()
 
 _filtered_datasets: Set[str] = sys.modules[__name__].__dict__.get('filtered_datasets', [])
 
 _extra_dataset: Union[dict, None] = sys.modules[__name__].__dict__.get('extra_dataset', None)
 
-_extra_dataset_parameters = '?' + '&'.join(list(f'{k}={v}' for (k,v) in _extra_dataset.items())) if _extra_dataset else ''
+from urllib import parse
+
+_extra_dataset_parameters = '?' + '&'.join(list(f'{parse.quote(k)}={parse.quote(v)}' for (k,v) in _extra_dataset.items())) if _extra_dataset else ''
 
 def _load_datasets(task: dict):
     if 'children' in task:
         for child in task['children']:
             dataset = keep_ascii_only(child['data']['name']).lower()
-            if dataset not in _filtered_datasets:
-                datasets.append(dataset)
+            if dataset not in datasets and dataset not in _filtered_datasets:
+                childCron = None if child['data'].get('cron') == 'None' else child['data'].get('cron')
+                if childCron :
+                    cronDatasets[dataset] = childCron
+                datasets.add(dataset)
             _load_datasets(child)
 
-if load_dependencies.lower() != 'true':
+if load_dependencies.lower() != 'true' and _cron is None :
     for task in task_deps:
         _load_datasets(task)
     schedule = list(map(lambda dataset: Dataset(dataset + _extra_dataset_parameters), datasets))
 
 tags = sl_job.get_context_var(var_name='tags', default_value="", options=options).split()
 
+from typing import List
+from croniter import croniter
+from datetime import datetime as dt
+
 # [START instantiate_dag]
 with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", "").lower(),
-         schedule_interval=None if cron == "None" else cron,
+         schedule_interval=_cron,
          schedule=schedule,
          default_args=sys.modules[__name__].__dict__.get('default_dag_args', DEFAULT_DAG_ARGS),
          catchup=False,
@@ -110,7 +123,23 @@ with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", ""
     else:
         start >> all_transform_tasks
 
-    end = sl_job.dummy_op(task_id="end", outlets=[Dataset(keep_ascii_only(dag.dag_id))]+list(map(lambda x: Dataset(x.uri + _extra_dataset_parameters), sl_job.outlets)))
+    extra: dict = {"source": dag.dag_id}
+    start = dt.fromtimestamp(dt.now().timestamp())
+    if _cron is not None :
+      extra['schedule'] = croniter(_cron, start).get_prev(dt).strftime('%Y-%m-%d')
+    outlets: List[Dataset] = [Dataset(keep_ascii_only(dag.dag_id), extra)] + list(map(lambda x: Dataset(x.uri + _extra_dataset_parameters, extra), sl_job.outlets))
+    if cronDatasets :
+      for dataset, cronDataset in cronDatasets.items() :
+        datasetNext = croniter(cronDataset, start).get_next(dt)
+        if start < datasetNext :
+          if _cron :
+            next = croniter(_cron, start).get_next(dt)
+            if next < datasetNext :
+                outlets.append(Dataset(dataset, extra))
+          else :
+              outlets.append(Dataset(dataset, extra))
+
+    end = sl_job.dummy_op(task_id="end", outlets=outlets)
 
     all_transform_tasks >> end
 

--- a/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
@@ -128,7 +128,7 @@ with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", ""
       parameters['sl_schedule'] = sl_schedule(_cron)
     outlets: List[Dataset] = [Dataset(keep_ascii_only(dag.dag_id), extra)] + list(map(lambda x: Dataset(x.uri + asQueryParameters(parameters), extra), sl_job.outlets))
     # we don't want to republish all scheduled datasets if there is none unscheduled datasets, otherwise the dag will be triggered indefinitely
-    if datasets.__len__() > 0:
+    if datasets.__len__() != cronDatasets.__len__():
       if cronDatasets :
           for dataset, _ in cronDatasets.items() :
             # we republish all scheduled datasets

--- a/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
@@ -29,11 +29,9 @@ cronDatasets: dict = dict()
 
 _filtered_datasets: Set[str] = sys.modules[__name__].__dict__.get('filtered_datasets', set())
 
-_extra_dataset: Union[dict, None] = sys.modules[__name__].__dict__.get('extra_dataset', None)
+_extra_dataset: dict = sys.modules[__name__].__dict__.get('extra_dataset', dict())
 
-from urllib import parse
-
-_extra_dataset_parameters = '?' + '&'.join(list(f'{parse.quote(k)}={parse.quote(v)}' for (k,v) in _extra_dataset.items())) if _extra_dataset else ''
+from typing import List
 
 def _load_datasets(task: dict):
     if 'children' in task:
@@ -42,29 +40,26 @@ def _load_datasets(task: dict):
             if dataset not in datasets and dataset not in _filtered_datasets:
                 childCron = None if child['data'].get('cron') == 'None' else child['data'].get('cron')
                 if childCron :
-                    cronDatasets[dataset] = childCron
-                datasets.add(dataset)
+                    parameters = dict(_extra_dataset)
+                    parameters['sl_schedule'] = sl_schedule(childCron)
+                    cronDataset = dataset + asQueryParameters(parameters)
+                    datasets.add(cronDataset)
+                    cronDatasets[cronDataset] = childCron
+                else :
+                  datasets.add(dataset)
             _load_datasets(child)
 
 if load_dependencies.lower() != 'true' :
     if not _cron:
         for task in task_deps:
             _load_datasets(task)
-    schedule = list(map(lambda dataset: Dataset(dataset + _extra_dataset_parameters), datasets))
+    schedule = list(map(lambda dataset: Dataset(dataset + asQueryParameters(_extra_dataset)), datasets))
 
 tags = sl_job.get_context_var(var_name='tags', default_value="", options=options).split()
 
-from typing import List
-from croniter import croniter
-from datetime import datetime as dt
-
-def cron_start_time() -> dt:
-    return dt.fromtimestamp(dt.now().timestamp())
-
 # [START instantiate_dag]
 with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", "").lower(),
-         schedule_interval=_cron,
-         schedule=schedule,
+         schedule=_cron if _cron else schedule,
          default_args=sys.modules[__name__].__dict__.get('default_dag_args', DEFAULT_DAG_ARGS),
          catchup=False,
          user_defined_macros=sys.modules[__name__].__dict__.get('user_defined_macros', None),
@@ -127,21 +122,17 @@ with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", ""
     else:
         start >> all_transform_tasks
 
+    parameters = dict(_extra_dataset)
     extra: dict = {"source": dag.dag_id}
-    start_time = cron_start_time()
     if _cron is not None :
-      extra['schedule'] = croniter(_cron, start_time).get_prev(dt).strftime('%Y-%m-%d')
-    outlets: List[Dataset] = [Dataset(keep_ascii_only(dag.dag_id), extra)] + list(map(lambda x: Dataset(x.uri + _extra_dataset_parameters, extra), sl_job.outlets))
-    if cronDatasets :
-      for dataset, cronDataset in cronDatasets.items() :
-        datasetNext = croniter(cronDataset, start_time).get_next(dt)
-        if start_time < datasetNext :
-          if _cron :
-            next = croniter(_cron, start_time).get_next(dt)
-            if next < datasetNext :
-                outlets.append(Dataset(dataset, extra))
-          else :
-              outlets.append(Dataset(dataset, extra))
+      parameters['sl_schedule'] = sl_schedule(_cron)
+    outlets: List[Dataset] = [Dataset(keep_ascii_only(dag.dag_id), extra)] + list(map(lambda x: Dataset(x.uri + asQueryParameters(parameters), extra), sl_job.outlets))
+    # we don't want to republish all scheduled datasets if there is none unscheduled datasets, otherwise the dag will be triggered indefinitely
+    if datasets.__len__() > 0:
+      if cronDatasets :
+          for dataset, _ in cronDatasets.items() :
+            # we republish all scheduled datasets
+            outlets.append(Dataset(dataset, extra))
 
     end = sl_job.dummy_op(task_id="end", outlets=outlets)
 

--- a/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
@@ -27,7 +27,7 @@ datasets: Set[str] = set()
 
 cronDatasets: dict = dict()
 
-_filtered_datasets: Set[str] = sys.modules[__name__].__dict__.get('filtered_datasets', [])
+_filtered_datasets: Set[str] = sys.modules[__name__].__dict__.get('filtered_datasets', set())
 
 _extra_dataset: Union[dict, None] = sys.modules[__name__].__dict__.get('extra_dataset', None)
 
@@ -46,9 +46,10 @@ def _load_datasets(task: dict):
                 datasets.add(dataset)
             _load_datasets(child)
 
-if load_dependencies.lower() != 'true' and _cron is None :
-    for task in task_deps:
-        _load_datasets(task)
+if load_dependencies.lower() != 'true' :
+    if not _cron:
+        for task in task_deps:
+            _load_datasets(task)
     schedule = list(map(lambda dataset: Dataset(dataset + _extra_dataset_parameters), datasets))
 
 tags = sl_job.get_context_var(var_name='tags', default_value="", options=options).split()
@@ -56,6 +57,9 @@ tags = sl_job.get_context_var(var_name='tags', default_value="", options=options
 from typing import List
 from croniter import croniter
 from datetime import datetime as dt
+
+def cron_start_time() -> dt:
+    return dt.fromtimestamp(dt.now().timestamp())
 
 # [START instantiate_dag]
 with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", "").lower(),
@@ -124,16 +128,16 @@ with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", ""
         start >> all_transform_tasks
 
     extra: dict = {"source": dag.dag_id}
-    start = dt.fromtimestamp(dt.now().timestamp())
+    start_time = cron_start_time()
     if _cron is not None :
-      extra['schedule'] = croniter(_cron, start).get_prev(dt).strftime('%Y-%m-%d')
+      extra['schedule'] = croniter(_cron, start_time).get_prev(dt).strftime('%Y-%m-%d')
     outlets: List[Dataset] = [Dataset(keep_ascii_only(dag.dag_id), extra)] + list(map(lambda x: Dataset(x.uri + _extra_dataset_parameters, extra), sl_job.outlets))
     if cronDatasets :
       for dataset, cronDataset in cronDatasets.items() :
-        datasetNext = croniter(cronDataset, start).get_next(dt)
-        if start < datasetNext :
+        datasetNext = croniter(cronDataset, start_time).get_next(dt)
+        if start_time < datasetNext :
           if _cron :
-            next = croniter(_cron, start).get_next(dt)
+            next = croniter(_cron, start_time).get_next(dt)
             if next < datasetNext :
                 outlets.append(Dataset(dataset, extra))
           else :

--- a/src/main/scala/ai/starlake/schema/generator/AutoTaskDependencies.scala
+++ b/src/main/scala/ai/starlake/schema/generator/AutoTaskDependencies.scala
@@ -50,7 +50,7 @@ class AutoTaskDependencies(
       config.tasks.getOrElse(Nil) match {
         case Nil =>
           if (config.all)
-            List("_lineage" -> TaskViewDependency.dependencies(tasks)(schemaHandler))
+            List("_lineage" -> TaskViewDependency.dependencies(tasks)(settings, schemaHandler))
           else
             Nil
         case taskOrDomainNames =>
@@ -66,7 +66,10 @@ class AutoTaskDependencies(
               taskOrDomainNames
             }
           taskNames.map(taskName =>
-            (taskName, TaskViewDependency.taskDependencies(taskName, tasks)(schemaHandler))
+            (
+              taskName,
+              TaskViewDependency.taskDependencies(taskName, tasks)(settings, schemaHandler)
+            )
           )
       }
     }

--- a/src/main/scala/ai/starlake/schema/generator/TaskViewDependency.scala
+++ b/src/main/scala/ai/starlake/schema/generator/TaskViewDependency.scala
@@ -72,6 +72,8 @@ object TaskViewDependency extends StrictLogging {
         SimpleEntry(jobName, TASK_TYPE, dependencies)
       }
 
+    val allTasks = schemaHandler.tasks()
+
     val jobAndViewDeps = jobDependencies.flatMap { case SimpleEntry(jobName, typ, parentRefs) =>
       logger.info(
         s"Analyzing dependency of type '$typ' for job '$jobName' with parent refs [${parentRefs.mkString(",")}]"
@@ -86,9 +88,9 @@ object TaskViewDependency extends StrictLogging {
             case 1 =>
               val tablePart = parts.last // == 0
               val refs =
-                tasks.filter(task =>
-                  task.taskDesc.name.endsWith(s".$tablePart") ||
-                  task.taskDesc.table.toLowerCase() == tablePart.toLowerCase()
+                allTasks.filter(task =>
+                  task.name.endsWith(s".$tablePart") ||
+                  task.table.toLowerCase() == tablePart.toLowerCase()
                 )
               if (refs.size > 1) {
                 throw new Exception(
@@ -100,18 +102,18 @@ object TaskViewDependency extends StrictLogging {
                 )
 
               } else
-                refs.headOption.map(ref => (ref.name, ref.taskDesc.schedule))
+                refs.headOption.map(ref => (ref.name, ref.schedule))
 
             case 2 | 3 =>
               val domainPart = parts.dropRight(1).last
               val tablePart = parts.last
-              tasks
+              allTasks
                 .find(task =>
-                  task.taskDesc.name.toLowerCase() == s"$domainPart.$tablePart".toLowerCase() ||
-                  (task.taskDesc.table.toLowerCase() == tablePart.toLowerCase() &&
-                  task.taskDesc.domain.toLowerCase() == domainPart.toLowerCase())
+                  task.name.toLowerCase() == s"$domainPart.$tablePart".toLowerCase() ||
+                  (task.table.toLowerCase() == tablePart.toLowerCase() &&
+                  task.domain.toLowerCase() == domainPart.toLowerCase())
                 )
-                .map(ref => (ref.name, ref.taskDesc.schedule))
+                .map(ref => (ref.name, ref.schedule))
             case _ =>
               val errors = schemaHandler.checkJobsVars().mkString("\n")
 

--- a/src/main/scala/ai/starlake/schema/generator/XlsDomainReader.scala
+++ b/src/main/scala/ai/starlake/schema/generator/XlsDomainReader.scala
@@ -53,12 +53,27 @@ class XlsDomainReader(input: Input) extends XlsModel {
         Option(
           row.getCell(headerMap("_tags"), Row.MissingCellPolicy.RETURN_BLANK_AS_NULL)
         ).flatMap(formatter.formatCellValue).map(_.split(",").toSet).getOrElse(Set.empty)
+      val dagRefOpt = Option(
+        row.getCell(headerMap("_dagRef"), Row.MissingCellPolicy.RETURN_BLANK_AS_NULL)
+      ).flatMap(formatter.formatCellValue)
+      val scheduleOpt =
+        Option(
+          row.getCell(headerMap("_frequency"), Row.MissingCellPolicy.RETURN_BLANK_AS_NULL)
+        )
+          .flatMap(formatter.formatCellValue)
       nameOpt match {
         case Some(name) =>
           Some(
             Domain(
               name,
-              metadata = Some(Metadata(directory = directoryOpt, ack = ack)),
+              metadata = Some(
+                Metadata(
+                  directory = directoryOpt,
+                  ack = ack,
+                  dagRef = dagRefOpt,
+                  schedule = scheduleOpt
+                )
+              ),
               comment = comment,
               tags = tags,
               rename = renameOpt
@@ -184,6 +199,12 @@ class XlsDomainReader(input: Input) extends XlsModel {
         row.getCell(headerMap("_dagRef"), Row.MissingCellPolicy.RETURN_BLANK_AS_NULL)
       ).flatMap(formatter.formatCellValue)
 
+      val scheduleOpt =
+        Option(
+          row.getCell(headerMap("_frequency"), Row.MissingCellPolicy.RETURN_BLANK_AS_NULL)
+        )
+          .flatMap(formatter.formatCellValue)
+
       val writeStrategy = (deltaColOpt, identityKeysOpt, mergeQueryFilter, write) match {
         case (Some(deltaCol), Some(identityKeys), filter, _) =>
           val strategyType =
@@ -273,7 +294,8 @@ class XlsDomainReader(input: Input) extends XlsModel {
             writeStrategy = Some(writeStrategy),
             quote = quoteOpt,
             nullValue = nullValueOpt,
-            dagRef = dagRefOpt
+            dagRef = dagRefOpt,
+            schedule = scheduleOpt
           )
 
           val tablePolicies = policiesOpt

--- a/src/main/scala/ai/starlake/schema/generator/XlsModel.scala
+++ b/src/main/scala/ai/starlake/schema/generator/XlsModel.scala
@@ -13,7 +13,9 @@ trait XlsModel {
     "_ack"         -> "Ack",
     "_description" -> "Description",
     "_rename"      -> "Rename",
-    "_tags"        -> "Tags"
+    "_tags"        -> "Tags",
+    "_dagRef"      -> "Dag reference",
+    "_frequency"   -> "Job frenquency"
   )
   val allPolicyHeaders = List(
     "_name"        -> "Name",
@@ -63,7 +65,8 @@ trait XlsModel {
     "_options"    -> "Spark ingestion options",
     "_validator"  -> "Class validator",
     "_null"       -> "Null value",
-    "_dagRef"     -> "Dag reference"
+    "_dagRef"     -> "Dag reference",
+    "_frequency"  -> "Job frenquency"
   )
 
   val allAttributeHeaders = List(

--- a/src/test/resources/sample/job/sql/_config.sl.yml
+++ b/src/test/resources/sample/job/sql/_config.sl.yml
@@ -11,6 +11,6 @@ transform:
         connectedRef: "spark"
         options:
           emptyValue: ""
-          delimiter: "|"
+          csv:delimiter: "|"
           ignoreLeadingWhiteSpace: false
           ignoreTrailingWhiteSpace: false

--- a/src/test/scala/ai/starlake/schema/handlers/AutoJobHandlerSpec.scala
+++ b/src/test/scala/ai/starlake/schema/handlers/AutoJobHandlerSpec.scala
@@ -154,7 +154,7 @@ class AutoJobHandlerSpec extends TestHelper with BeforeAndAfterAll {
       val schemaHandler = new SchemaHandler(storageHandler)
 
       val tasks = AutoTask.unauthenticatedTasks(true)(settings, storageHandler, schemaHandler)
-      val deps = TaskViewDependency.dependencies(tasks)(schemaHandler)
+      val deps = TaskViewDependency.dependencies(tasks)(settings, schemaHandler)
       deps.map(_.parentRef) should contain theSameElementsAs List(
         "parquet." + userView,
         "user_view"


### PR DESCRIPTION
## Summary
The goal of this PR is to support data lineage freshness in dags generated by Starlake for Airflow.

Data lineage is implemented within Airflow by using data-aware scheduling.

Each time a load or transformation is executed within a dag, Starlake will produce the corresponding Dataset using outlets.

Similarly, when a transformation requires that other load(s) or transformation(s) be performed beforehand, Starlake will add them as a list of Datasets to the corresponding consumer dag so that the dag will be automatically triggered each time all the datasets would have been produced .

The problems start when a dag has dependencies on Datasets that are produced by dag(s) whose frequency(ies) may differ. 

For example a dag may depend on one Dataset A that is produced once a month and another Dataset B that is  produced daily... 
At the end the dag will be triggered not every day as expected but not before the dag that produces Dataset A will be triggered, which means once a month.

The freshness of the data will ultimately be defined by the dataset updated the least frequently.

The solution consists of ensuring that all datasets produced by a dag for which a cron has been defined are republished identically by the consumer dag.

This solution implies : 

- adding the optional schedule (cron) for each dependency computed for dags
- adding to the uri of each dataset produced by a dag for which a cron has been defined, in the form of a query parameter (sl_schedule), the logical date time of the dag
- adding to the uri of each dataset consumed by a dag for which the corresponding dependency has defined a cron, in the form of a query parameter (sl_schedule), the last logical date time the dataset should have been produced
- republishing those scheduled datasets



**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**
