### PR TITLE
feat: make comet_input_file_name in bigquery native load as precise as in spark when files are grouped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ __New Feature__:
 - migrate command added in order to ease migration between version
 - domain template used during schema extraction is now splitted in two files: domain-template and table-template. Table-template are prefixed with `_table_` and domain template may be prefixed with `_domain_` with the config file name. Ex: `_table_config.sl.yml`.
 - CURRENT_DATE, CURRENT_TIME and CURRENT_TIMESTAMP are now supported on a per call level during tests
+- make comet_input_file_name in bigquery native load as precise as in spark when files are grouped
 
 __Bug Fix__:
 - Amazon RedShift write strategy templates

--- a/src/main/resources/templates/write-strategies/bigquery/append.j2
+++ b/src/main/resources/templates/write-strategies/bigquery/append.j2
@@ -4,4 +4,4 @@
 TRUNCATE TABLE {{ tableFullName }};
 {% endif %}
 
-INSERT INTO {{ tableFullName }} {{ selectStatement }}
+INSERT INTO {{ tableFullName }}({{ tableColumnsCsv }}) {{ selectStatement }}

--- a/src/main/resources/templates/write-strategies/bigquery/overwrite.j2
+++ b/src/main/resources/templates/write-strategies/bigquery/overwrite.j2
@@ -5,5 +5,5 @@ DROP MATERIALIZED VIEW IF EXISTS {{ tableFullName }};
 CREATE MATERIALIZED VIEW {{ tableFullName }} AS {{ selectStatement }}
 {% else %}
 TRUNCATE TABLE {{ tableFullName }};
-INSERT INTO {{ tableFullName }} {{ selectStatement }}
+INSERT INTO {{ tableFullName }}({{ tableColumnsCsv }}) {{ selectStatement }}
 {% endif %}

--- a/src/main/scala/ai/starlake/job/ingest/BigQueryNativeIngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/BigQueryNativeIngestionJob.scala
@@ -1,15 +1,21 @@
 package ai.starlake.job.ingest
 
-import ai.starlake.config.Settings
+import ai.starlake.config.{CometColumns, Settings}
 import ai.starlake.exceptions.NullValueFoundException
-import ai.starlake.job.sink.bigquery.{BigQueryJobBase, BigQueryLoadConfig, BigQueryNativeJob}
+import ai.starlake.job.sink.bigquery.{
+  BigQueryJobBase,
+  BigQueryJobResult,
+  BigQueryLoadConfig,
+  BigQueryNativeJob
+}
 import ai.starlake.job.transform.{AutoTask, BigQueryAutoTask}
 import ai.starlake.schema.handlers.{SchemaHandler, StorageHandler}
 import ai.starlake.schema.model._
 import ai.starlake.sql.SQLUtils
 import ai.starlake.utils.conversion.BigQueryUtils
 import ai.starlake.utils.{IngestionCounters, JobResult, Utils}
-import com.google.cloud.bigquery.{Schema => BQSchema, TableId}
+import com.google.cloud.bigquery
+import com.google.cloud.bigquery.{Field, StandardSQLTypeName, TableId}
 import com.typesafe.scalalogging.StrictLogging
 import com.univocity.parsers.csv.{CsvFormat, CsvParser, CsvParserSettings}
 import org.apache.hadoop.fs.Path
@@ -85,40 +91,79 @@ class BigQueryNativeIngestionJob(ingestionJob: IngestionJob, accessToken: Option
         )
       val twoSteps = requireTwoSteps(effectiveSchema, bqSink)
       if (twoSteps) {
-        val firstStepTempTable =
-          BigQueryJobBase.extractProjectDatasetAndTable(
-            schemaHandler.getDatabase(domain),
-            domain.finalName,
-            SQLUtils.temporaryTableName(effectiveSchema.finalName)
-          )
-        val firstStepConfig =
-          targetConfig
-            .copy(
-              outputTableId = Some(firstStepTempTable),
-              outputTableDesc = Some("Temporary table created during data ingestion."),
-              days = Some(1)
+        val (loadResults, tempTableIds, tableInfos) =
+          path
+            .map(_.toString)
+            .foldLeft[(List[Try[BqLoadInfo]], List[TableId], List[TableInfo])]((Nil, Nil, Nil)) {
+              case ((loadResultList, tempTableIdList, tableInfoList), sourceUri) =>
+                val firstStepTempTable =
+                  BigQueryJobBase.extractProjectDatasetAndTable(
+                    schemaHandler.getDatabase(domain),
+                    domain.finalName,
+                    SQLUtils.temporaryTableName(effectiveSchema.finalName)
+                  )
+                val firstStepConfig =
+                  targetConfig
+                    .copy(
+                      source = Left(sourceUri),
+                      outputTableId = Some(firstStepTempTable),
+                      outputTableDesc = Some("Temporary table created during data ingestion."),
+                      days = Some(1)
+                    )
+
+                val firstStepBigqueryJob = new BigQueryNativeJob(firstStepConfig, "")
+                val firstStepTableInfo = firstStepBigqueryJob.getTableInfo(
+                  firstStepTempTable,
+                  _.bqSchemaWithIgnoreAndScript(schemaHandler)
+                )
+
+                val enrichedTableInfo = firstStepTableInfo.copy(maybeSchema =
+                  firstStepTableInfo.maybeSchema.map((schema: bigquery.Schema) =>
+                    bigquery.Schema.of(
+                      (schema.getFields.asScala :+
+                      Field
+                        .newBuilder(
+                          CometColumns.cometInputFileNameColumn,
+                          StandardSQLTypeName.STRING
+                        )
+                        .setDefaultValueExpression(s"'$sourceUri'")
+                        .build()).asJava
+                    )
+                  )
+                )
+
+                // TODO What if type is changed by transform ? we need to use safe_cast to have the same behavior as in SPARK.
+                val firstStepResult =
+                  firstStepBigqueryJob.loadPathsToBQ(firstStepTableInfo, Some(enrichedTableInfo))
+                (
+                  loadResultList :+ firstStepResult,
+                  tempTableIdList :+ firstStepTempTable,
+                  tableInfoList :+ enrichedTableInfo
+                )
+            }
+        def combineStats(bqLoadInfo1: BqLoadInfo, bqLoadInfo2: BqLoadInfo): BqLoadInfo = {
+          BqLoadInfo(
+            bqLoadInfo1.totalAcceptedRows + bqLoadInfo2.totalAcceptedRows,
+            bqLoadInfo1.totalRejectedRows + bqLoadInfo2.totalRejectedRows,
+            jobResult = BigQueryJobResult(
+              None,
+              bqLoadInfo1.jobResult.totalBytesProcessed + bqLoadInfo2.jobResult.totalBytesProcessed,
+              None
             )
+          )
+        }
+        val globalLoadResult: Try[BqLoadInfo] = loadResults.reduce { (result1, result2) =>
+          result1.flatMap(r => result2.map(combineStats(_, r)))
+        }
 
-        val firstStepBigqueryJob = new BigQueryNativeJob(firstStepConfig, "")
-        val firstStepTableInfo = firstStepBigqueryJob.getTableInfo(
-          firstStepTempTable,
-          _.bqSchemaWithIgnoreAndScript(schemaHandler)
-        )
-
-        // TODO What if type is changed by transform ? we need to use safe_cast to have the same behavior as in SPARK.
-        val firstStepResult =
-          firstStepBigqueryJob.loadPathsToBQ(firstStepTableInfo)
-
-        val targetTableSchema: BQSchema = effectiveSchema.bqSchemaWithoutIgnore(schemaHandler)
         val output: Try[BqLoadInfo] =
           applyBigQuerySecondStep(
-            targetTableSchema,
             targetConfig,
-            firstStepTempTable,
-            firstStepResult
+            tempTableIds,
+            globalLoadResult
           )
-        archiveTable(firstStepTempTable, firstStepTableInfo)
-        Try(firstStepBigqueryJob.dropTable(firstStepTempTable))
+        tempTableIds.zip(tableInfos).foreach { case (id, info) => archiveTable(id, info) }
+        Try(tempTableIds.foreach(new BigQueryNativeJob(targetConfig, "").dropTable))
           .flatMap(_ => output)
           .recoverWith { case exception =>
             Utils.logException(logger, exception)
@@ -198,9 +243,8 @@ class BigQueryNativeIngestionJob(ingestionJob: IngestionJob, accessToken: Option
   }
 
   private def applyBigQuerySecondStep(
-    targetTableSchema: BQSchema,
     targetConfig: BigQueryLoadConfig,
-    firstStepTempTable: TableId,
+    firstStepTempTable: List[TableId],
     firstStepResult: Try[BqLoadInfo]
   ): Try[BqLoadInfo] = {
     firstStepResult match {
@@ -338,17 +382,19 @@ class BigQueryNativeIngestionJob(ingestionJob: IngestionJob, accessToken: Option
   }
 
   def applyBigQuerySecondStepSQL(
-    firstStepTempTableId: TableId,
+    firstStepTempTableId: List[TableId],
     starlakeSchema: Schema
   ): Try[JobResult] = {
     val incomingSparkSchema = starlakeSchema.sparkSchemaWithoutIgnore(schemaHandler)
 
-    val tempTable = BigQueryUtils.tableIdToTableName(firstStepTempTableId)
-    val sourceUris = path.map(_.toString).mkString(",").replace("'", "\\'")
+    val tempTable = firstStepTempTableId
+      .map(BigQueryUtils.tableIdToTableName)
+      .map("SELECT * FROM " + _)
+      .mkString("(", " UNION ALL ", ")")
     val targetTableName = s"${domain.finalName}.${schema.finalName}"
 
     val sqlWithTransformedFields =
-      starlakeSchema.buildSqlSelectOnLoad(tempTable, Some(sourceUris))
+      starlakeSchema.buildSqlSelectOnLoad(tempTable)
 
     val taskDesc = AutoTaskDesc(
       name = targetTableName,

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQueryNativeJob.scala
@@ -38,8 +38,16 @@ class BigQueryNativeJob(
 
   logger.debug(s"BigQuery Config $cliConfig")
 
-  def loadPathsToBQ(tableInfo: SLTableInfo): Try[BqLoadInfo] = {
-    getOrCreateTable(cliConfig.domainDescription, tableInfo, None).flatMap { _ =>
+  def loadPathsToBQ(
+    tableInfo: SLTableInfo,
+    tableInfoWithDefaultColumn: scala.Option[SLTableInfo] = None
+  ): Try[BqLoadInfo] = {
+    // have default column in another tableInfo otherwise load doesn't fill with default value. Column in load schema are then null if they doesn't exist.
+    getOrCreateTable(
+      cliConfig.domainDescription,
+      tableInfoWithDefaultColumn.getOrElse(tableInfo),
+      None
+    ).flatMap { _ =>
       Try {
         val bqSchema =
           tableInfo.maybeSchema.getOrElse(throw new RuntimeException("Should never happen"))

--- a/src/main/scala/ai/starlake/schema/model/Schema.scala
+++ b/src/main/scala/ai/starlake/schema/model/Schema.scala
@@ -548,21 +548,8 @@ case class Schema(
     *   query
     */
   def buildSqlSelectOnLoad(
-    table: String,
-    sourceUris: Option[String]
+    table: String
   ): String = {
-    val tableWithInputFileName = {
-      sourceUris match {
-        case None => table
-        case Some(sourceUris) =>
-          s"""
-         |(
-         | SELECT *, '${sourceUris}' as ${CometColumns.cometInputFileNameColumn} FROM $table
-         |)
-         |""".stripMargin
-      }
-    }
-
     val (scriptAttributes, transformAttributes) =
       scriptAndTransformAttributes().partition(_.script.nonEmpty)
 
@@ -608,7 +595,7 @@ case class Schema(
        |SELECT $allFinalAttributes
        |  FROM (
        |    SELECT $allAttributes
-       |    FROM $tableWithInputFileName
+       |    FROM $table
        |  ) AS SL_INTERNAL_FROM_SELECT
        |  $sourceTableFilterSQL
        |""".stripMargin

--- a/src/main/scala/ai/starlake/sql/SQLUtils.scala
+++ b/src/main/scala/ai/starlake/sql/SQLUtils.scala
@@ -139,7 +139,13 @@ object SQLUtils extends StrictLogging {
         t.withTimeOut(60 * 1000)
       }
     }
-    CCJSqlParserUtil.parse(parseable, features)
+    try {
+      CCJSqlParserUtil.parse(parseable, features)
+    } catch {
+      case exception: Exception =>
+        logger.error(s"Failed to parse $sql")
+        throw exception
+    }
   }
 
   def substituteRefInSQLSelect(


### PR DESCRIPTION
When SL_GROUPED is set to true, comet_input_file_name is set to a list of files in bigquery native load because all files are loaded into the same target table. This is not the same behavior with spark loading, where spark links data to the original source file.

This PR aims to fill the gap between spark and bq native load.