### PR TITLE
specify default CSV nullstr option for duckdb while running unit tests

### DIFF
--- a/samples/spark/sample-data/hr/flat_locations-2018-01-01.json
+++ b/samples/spark/sample-data/hr/flat_locations-2018-01-01.json
@@ -1,0 +1,2 @@
+{  "id":"1", "city":"Paris",    "country":"France" }
+{  "id":"2",  "city":"Berlin",  "country":"Germany"  }

--- a/src/main/scala/ai/starlake/tests/StarlakeTests.scala
+++ b/src/main/scala/ai/starlake/tests/StarlakeTests.scala
@@ -738,7 +738,8 @@ object StarlakeTestData {
             ""
         val extraArgs =
           if (firstLine.startsWith("[")) "(FORMAT JSON, ARRAY true)"
-          else if (dataFile.getName.endsWith("csv")) "(FORMAT CSV, nullstr 'null')"
+          else if (dataFile.getName.endsWith("csv"))
+            s"(FORMAT CSV, nullstr '${schemaHandler.activeEnvVars().getOrElse("SL_CSV_NULLSTR", "null")}')"
           else ""
         s"""CREATE TABLE "$domainName"."$tableName" ($cols);
                  |COPY "$domainName"."$tableName" FROM '${dataFile.toString}' $extraArgs;""".stripMargin
@@ -746,7 +747,7 @@ object StarlakeTestData {
         // Table not present in starlake schema, we let duckdb infer the schema
         val source =
           if (dataFile.getName.endsWith("csv"))
-            s"read_csv('${dataFile.toString}', nullstr = 'null')"
+            s"read_csv('${dataFile.toString}', nullstr = '${schemaHandler.activeEnvVars().getOrElse("SL_CSV_NULLSTR", "null")}')"
           else s"'${dataFile.toString}'"
         s"CREATE TABLE $domainName.$tableName AS SELECT * FROM $source;"
     }

--- a/src/main/scala/ai/starlake/tests/StarlakeTests.scala
+++ b/src/main/scala/ai/starlake/tests/StarlakeTests.scala
@@ -738,12 +738,17 @@ object StarlakeTestData {
             ""
         val extraArgs =
           if (firstLine.startsWith("[")) "(FORMAT JSON, ARRAY true)"
+          else if (dataFile.getName.endsWith("csv")) "(FORMAT CSV, nullstr 'null')"
           else ""
         s"""CREATE TABLE "$domainName"."$tableName" ($cols);
                  |COPY "$domainName"."$tableName" FROM '${dataFile.toString}' $extraArgs;""".stripMargin
       case None =>
         // Table not present in starlake schema, we let duckdb infer the schema
-        s"CREATE TABLE $domainName.$tableName AS SELECT * FROM '${dataFile.toString}';"
+        val source =
+          if (dataFile.getName.endsWith("csv"))
+            s"read_csv('${dataFile.toString}', nullstr = 'null')"
+          else s"'${dataFile.toString}'"
+        s"CREATE TABLE $domainName.$tableName AS SELECT * FROM $source;"
     }
     expectedCreateTable
   }

--- a/src/test/scala/ai/starlake/job/sink/es/ESLoadJobSpec.scala
+++ b/src/test/scala/ai/starlake/job/sink/es/ESLoadJobSpec.scala
@@ -10,7 +10,7 @@ class ESLoadJobSpec extends TestHelper {
         """
           |Usage: starlake esload [options]
           |
-          |  --timestamp <value>      Elasticsearch index timestamp suffix as in {@timestamp|yyyy.MM.dd}
+          |  --timestamp <value>      Elasticsearch index timestamp suffix as in `{@timestamp\|yyyy.MM.dd}`
           |  --id <value>             Elasticsearch Document Id
           |  --mapping <value>        Path to Elasticsearch Mapping File
           |  --domain <value>         Domain Name


### PR DESCRIPTION
## Summary
To specify  a default CSV nullstr option for duckdb while running unit tests

**Related Issue: #945 **

**PR Type: Bug Fix**

**Status: WIP**

**Breaking change? No**



