### PR TITLE
fix: gcp log struct serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 # 1.2.2
 __Bug Fix__:
 - fix usage of technical columns when load table is set to overwrite
+- fix gcp log serialization
 
 # 1.2.1
 

--- a/src/test/scala/ai/starlake/serve/SettingsManagerSpec.scala
+++ b/src/test/scala/ai/starlake/serve/SettingsManagerSpec.scala
@@ -14,6 +14,7 @@ class SettingsManagerSpec extends TestHelper {
       val oldDatabase = settings.appConfig.database
       val (settings2, isNew) =
         CaffeineSettingsManager.getUpdatedSettings(
+          "",
           "/tmp/my/settings/home",
           Some("test"),
           false
@@ -22,6 +23,7 @@ class SettingsManagerSpec extends TestHelper {
       settings2.appConfig.root shouldBe "/tmp/my/settings/home"
 
       CaffeineSettingsManager.getUpdatedSettings(
+        "",
         oldRoot,
         Option(oldEnv),
         false

--- a/src/test/scala/ai/starlake/utils/GcpUtilsTest.scala
+++ b/src/test/scala/ai/starlake/utils/GcpUtilsTest.scala
@@ -1,0 +1,108 @@
+package ai.starlake.utils
+import ai.starlake.job.ingest.RejectedRecord
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+
+class GcpUtilsTest extends AnyFlatSpec with Matchers {
+
+  "GcpUtils" should "adapt input values not supported by Gcp Struct" in {
+    val timestamp = java.sql.Timestamp.from(Instant.now())
+    val rejectedRecord = RejectedRecord(
+      jobid = "job_id",
+      timestamp = timestamp,
+      domain = "domain",
+      schema = "schema",
+      error = "error",
+      path = "path"
+    )
+    val rejectedRecordOutput: Map[String, Any] =
+      GcpUtils.adapt_map_to_gcp_log(rejectedRecord.asMap())
+    rejectedRecordOutput should contain allOf (
+      "jobid"     -> "job_id",
+      "timestamp" -> timestamp.getTime,
+      "domain"    -> "domain",
+      "schema"    -> "schema",
+      "error"     -> "error",
+      "path"      -> "path"
+    )
+
+    object DummyEnum extends Enumeration {
+      type DummyEnum = Value
+      val Is, A, Dummy, Enumeration = Value
+    }
+
+    val current_instant = java.time.Instant.now()
+
+    val variousTypes: Map[String, Any] = Map(
+      "aString"    -> "aString",
+      "aTimestamp" -> timestamp,
+      "anInt"      -> 1,
+      "aLong"      -> 1L,
+      "aFloat"     -> 1.0f,
+      "aDouble"    -> 1.0d,
+      "anEnum"     -> DummyEnum.Dummy,
+      "anInstant"  -> current_instant,
+      "aNull"      -> null,
+      (null, "Strange null key"),
+      "aMap" -> Map(
+        "aString"    -> "aString",
+        "aTimestamp" -> timestamp,
+        "anInt"      -> 1,
+        "aLong"      -> 1L,
+        "aFloat"     -> 1.0f,
+        "aDouble"    -> 1.0d,
+        "anEnum"     -> DummyEnum.Dummy,
+        "anInstant"  -> current_instant
+      ),
+      "aList" -> List(
+        Map(
+          "aString"    -> "aString",
+          "aTimestamp" -> timestamp,
+          "anInt"      -> 1,
+          "aLong"      -> 1L,
+          "aFloat"     -> 1.0f,
+          "aDouble"    -> 1.0d,
+          "anEnum"     -> DummyEnum.Dummy,
+          "anInstant"  -> current_instant
+        )
+      )
+    )
+    val output: Map[String, Any] = GcpUtils.adapt_map_to_gcp_log(variousTypes)
+    output should contain allOf (
+      "aString"    -> "aString",
+      "aTimestamp" -> timestamp.getTime,
+      "anInt"      -> 1,
+      "aLong"      -> 1L,
+      "aFloat"     -> 1.0f,
+      "aDouble"    -> 1.0d,
+      "anEnum"     -> DummyEnum.Dummy.toString,
+      "anInstant"  -> current_instant.toString,
+      "aNull"      -> null,
+      (null, "Strange null key"),
+      "aMap" -> Map(
+        "aString"    -> "aString",
+        "aTimestamp" -> timestamp.getTime,
+        "anInt"      -> 1,
+        "aLong"      -> 1L,
+        "aFloat"     -> 1.0f,
+        "aDouble"    -> 1.0d,
+        "anEnum"     -> DummyEnum.Dummy.toString,
+        "anInstant"  -> current_instant.toString
+      ),
+      "aList" -> List(
+        Map(
+          "aString"    -> "aString",
+          "aTimestamp" -> timestamp.getTime,
+          "anInt"      -> 1,
+          "aLong"      -> 1L,
+          "aFloat"     -> 1.0f,
+          "aDouble"    -> 1.0d,
+          "anEnum"     -> DummyEnum.Dummy.toString,
+          "anInstant"  -> current_instant.toString
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
While using spark as load and gcp log sink, output could not be serialized (rejectedRecord here).

We get the following stack trace:

java.lang.IllegalArgumentException: Unsupported protobuf value 2024-09-20 11:36:59.753828
	at com.google.cloud.Structs.objectToValue(Structs.java:147)
	at shade.com.google.common.collect.Maps$9.transformEntry(Maps.java:2117)
	at shade.com.google.common.collect.Maps$12.getValue(Maps.java:2165)
	at shade.com.google.protobuf.Struct$Builder.putAllFields(Struct.java:623)
	at com.google.cloud.Structs.newStruct(Structs.java:101)
	at com.google.cloud.logging.Payload$JsonPayload.of(Payload.java:121)
	at ai.starlake.utils.GcpUtils$.sinkToGcpCloudLogging(GcpUtils.scala:53)
	at ai.starlake.job.ingest.IngestionUtil$.$anonfun$sinkRejected$4(IngestionUtil.scala:76)
	at ai.starlake.job.ingest.IngestionUtil$.$anonfun$sinkRejected$4$adapted(IngestionUtil.scala:75)
	at scala.collection.ArrayOps$.map$extension(ArrayOps.scala:929)
	at ai.starlake.job.ingest.IngestionUtil$.sinkRejected(IngestionUtil.scala:75)
	at ai.starlake.job.ingest.IngestionJob.saveRejected(IngestionJob.scala:876)
	at ai.starlake.job.ingest.IngestionJob.saveRejected$(IngestionJob.scala:843)
	at ai.starlake.job.ingest.JsonIngestionJob.saveRejected(JsonIngestionJob.scala:49)
	at ai.starlake.job.ingest.JsonIngestionJob.ingest(JsonIngestionJob.scala:175)
	at ai.starlake.job.ingest.IngestionJob.$anonfun$ingestWithSpark$1(IngestionJob.scala:410)
	at scala.util.Try$.apply(Try.scala:210)

This PR adapt the map before calling JsonPayload.of.


