### PR TITLE
fix: json tree validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 __Bug Fix__:
 - fix usage of technical columns when load table is set to overwrite
 - fix gcp log serialization
+- fix tree validation
 
 # 1.2.1
 


### PR DESCRIPTION
This PR fixes tree validation:
  - invalid name comparison
  - fix index increment based on the resulting name comparison
  - struct context was invalid in the error built