### PR TITLE
fix template resolution && merge statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ __Bug Fix__:
 - fix tree validation
 - fix intermediate format to orc rules
 - fix conversion from spark schema to starlake schema
+- fix template resolution
+- fix merge statement when used with quoted column
 
 # 1.2.1
 

--- a/src/main/scala/ai/starlake/job/ingest/loaders/BigQueryNativeLoader.scala
+++ b/src/main/scala/ai/starlake/job/ingest/loaders/BigQueryNativeLoader.scala
@@ -399,8 +399,9 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
       .mkString("(", " UNION ALL ", ")")
     val targetTableName = s"${domain.finalName}.${schema.finalName}"
 
+    val bigqueryEngine = settings.appConfig.jdbcEngines.get("bigquery")
     val sqlWithTransformedFields =
-      starlakeSchema.buildSqlSelectOnLoad(tempTable)
+      starlakeSchema.buildSqlSelectOnLoad(tempTable, bigqueryEngine)
 
     val taskDesc = AutoTaskDesc(
       name = targetTableName,

--- a/src/main/scala/ai/starlake/sql/SQLUtils.scala
+++ b/src/main/scala/ai/starlake/sql/SQLUtils.scala
@@ -399,7 +399,7 @@ object SQLUtils extends StrictLogging {
     targetTableColumns: List[String],
     quote: String
   ): String =
-    targetTableColumns
+    unquoteCols(targetTableColumns, quote)
       .map(col => s"$quote$col$quote = $incomingTable.$quote$col$quote")
       .mkString("SET ", ",", "")
 

--- a/src/main/scala/ai/starlake/utils/AnyTemplateLoader.scala
+++ b/src/main/scala/ai/starlake/utils/AnyTemplateLoader.scala
@@ -218,11 +218,14 @@ abstract class AnyTemplateLoader extends LazyLogging {
     template: String
   )(implicit settings: Settings): Try[String] = {
     val templatePath = new Path(template)
-    if (settings.storageHandler().exists(templatePath)) {
-      Success(settings.storageHandler().read(templatePath))
-    } else {
-      Failure(new RuntimeException(s"No absolute template found for ${templatePath}."))
-    }
+    Try {
+      // exists may throw an exception
+      if (settings.storageHandler().exists(templatePath)) {
+        Success(settings.storageHandler().read(templatePath))
+      } else {
+        Failure(new RuntimeException(s"No absolute template found for ${templatePath}."))
+      }
+    }.flatten
   }
 
   def loadTemplateFromAppPath(template: String)(implicit settings: Settings): Try[String] = {


### PR DESCRIPTION
When starlake is trying to load from absolute path, if the path doesn't exists, an exception is thrown but not catched. This fix makes it able to fallback to other resolution.

During merge statement, update clause set the different columns but doesn't try to unescape column before escaping it again.
