### PR TITLE
define each grantee with potential multiple values

### DIFF
--- a/src/main/scala/ai/starlake/schema/model/RowLevelSecurity.scala
+++ b/src/main/scala/ai/starlake/schema/model/RowLevelSecurity.scala
@@ -23,7 +23,7 @@ case class RowLevelSecurity(
   def this() = this("") // Should never be called. Here for Jackson deserialization only
 
   def grantees(): Set[(UserType, String)] = {
-    grants.map { user =>
+    grants.flatMap(grant => grant.split(",").map(_.replaceAll("\"", ""))).map { user =>
       val res = user.split(':')
       assert(res.length == 2)
       (UserType.fromString(res(0).trim), res(1).trim)


### PR DESCRIPTION
 (usefull when a grantee is defined using an external variable, eg terraform variable)

## Summary
Using excel configuration files, when defining policies whose user groups rely on external variables, after applying xls2yml we will end up with something like : 

```
  acl:
  - role: "roles/bigquery.dataViewer"
    grants:
    - "${my_members}"
    - "user:another_member"
#...
```
This PR is to ensure that, in this case, all the members will be accordingly taken into account

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**
