### PR TITLE
 [BUG] - extract from duckdb (tutorial) not working with error java.sql.SQLException: Connection Error: Can't open a connection to same database #1087 

### DIFF
--- a/src/main/scala/ai/starlake/extract/ExtractDataJob.scala
+++ b/src/main/scala/ai/starlake/extract/ExtractDataJob.scala
@@ -777,7 +777,7 @@ class ExtractDataJob(schemaHandler: SchemaHandler) extends Extract with LazyLogg
           val boundaries = if (extractConfig.data.options == extractConfig.audit.options) {
             getBoundariesWith(connection)
           } else {
-            withJDBCConnection(extractConfig.audit.options) { auditConnection =>
+            withJDBCConnection(readOnlyConnection(extractConfig.audit.options)) { auditConnection =>
               getBoundariesWith(auditConnection)
             }
           }

--- a/src/main/scala/ai/starlake/extract/ExtractDataJob.scala
+++ b/src/main/scala/ai/starlake/extract/ExtractDataJob.scala
@@ -837,8 +837,8 @@ class ExtractDataJob(schemaHandler: SchemaHandler) extends Extract with LazyLogg
   private[extract] def initExportAuditTable(
     connectionSettings: Connection
   )(implicit settings: Settings): Columns = {
+    val auditSchema = settings.appConfig.audit.domain.getOrElse("audit")
     withJDBCConnection(connectionSettings.options) { connection =>
-      val auditSchema = settings.appConfig.audit.domain.getOrElse("audit")
       val existLastExportTable =
         tableExists(connection, connectionSettings.jdbcUrl, s"${auditSchema}.$lastExportTableName")
       if (!existLastExportTable && settings.appConfig.createSchemaIfNotExists) {
@@ -859,7 +859,6 @@ class ExtractDataJob(schemaHandler: SchemaHandler) extends Extract with LazyLogg
         }
       }
     }
-    val auditSchema = settings.appConfig.audit.domain.getOrElse("audit")
     JdbcDbUtils
       .extractJDBCTables(
         JDBCSchema(


### PR DESCRIPTION
## Summary
extract from duckdb (tutorial) not working with error  Exception in thread "main" java.sql.SQLException: Connection Error: Can't open a connection to same database file with a different configuration than existing connections. connections are not closing correctly. 

**Related Issue: #IssueId**

**PR Type: Bug Fix |**

**Status: WIP/Ready to review**

**Breaking change? Yes/No**


## Description
### Solution


we can enforce readonly and permit RW connection only on audit insertions with proper close connection.



