### PR TITLE
Filter properly dag assets / datasets + handle dependencies between first level tasks only when load_dependencies = False

### DIFF
--- a/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
@@ -117,13 +117,12 @@ with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", ""
         else:
             airflow_task_id = airflow_task_group_id + "_table"
 
-        children =
-            if load_dependencies: 
-                task.get('children', [])
-            else:
-                _children = []
-                for child in task.get('children', []):
-                    if child['data']['name'] in first_level_tasks:
+        children = []
+        if load_dependencies and 'children' in task: 
+            children = task['children']
+        else:
+            for child in task.get('children', []):
+                if child['data']['name'] in first_level_tasks:
                         _children.append(child)
                 _children
 

--- a/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
@@ -19,7 +19,7 @@ _cron = None if cron == "None" else cron
 
 task_deps=json.loads("""{{ context.dependencies }}""")
 
-load_dependencies = sl_job.get_context_var(var_name='load_dependencies', default_value='False', options=options)
+load_dependencies: bool = sl_job.get_context_var(var_name='load_dependencies', default_value='False', options=options).lower() == 'true'
 
 schedule = None
 
@@ -31,6 +31,8 @@ _filtered_datasets: Set[str] = sys.modules[__name__].__dict__.get('filtered_data
 
 from typing import List
 
+first_level_tasks: set = set()
+
 dependencies: set = set()
 
 def load_task_dependencies(task):
@@ -40,6 +42,7 @@ def load_task_dependencies(task):
             load_task_dependencies(subtask)
 
 for task in task_deps:
+    first_level_tasks.add(task['data']['name'])
     _filtered_datasets.add(sanitize_id(task['data']['name']).lower())
     load_task_dependencies(task)
 
@@ -56,7 +59,7 @@ def _load_datasets(task: dict):
                 else :
                   datasets.add(dataset)
 
-if load_dependencies.lower() != 'true' :
+if load_dependencies :
     if not _cron:
         for task in task_deps:
             _load_datasets(task)
@@ -114,9 +117,19 @@ with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", ""
         else:
             airflow_task_id = airflow_task_group_id + "_table"
 
-        if (load_dependencies.lower() == 'true' and 'children' in task):
+        children =
+            if load_dependencies: 
+                task.get('children', [])
+            else:
+                _children = []
+                for child in task.get('children', []):
+                    if child['data']['name'] in first_level_tasks:
+                        _children.append(child)
+                _children
+
+        if children.__len__() > 0:
             with TaskGroup(group_id=airflow_task_group_id) as airflow_task_group:
-                for transform_sub_task in task['children']:
+                for transform_sub_task in children:
                     generate_task_group_for_task(transform_sub_task)
                 upstream_tasks = list(airflow_task_group.children.values())
                 airflow_task = create_task(airflow_task_id, task_name, task_type)

--- a/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
@@ -31,6 +31,18 @@ _filtered_datasets: Set[str] = sys.modules[__name__].__dict__.get('filtered_data
 
 from typing import List
 
+dependencies: set = set()
+
+def load_task_dependencies(task):
+    if 'children' in task:
+        for subtask in task['children']:
+            dependencies.add(subtask['data']['name'])
+            load_task_dependencies(subtask)
+
+for task in task_deps:
+    _filtered_datasets.add(sanitize_id(task['data']['name']).lower())
+    load_task_dependencies(task)
+
 def _load_datasets(task: dict):
     if 'children' in task:
         for child in task['children']:
@@ -43,7 +55,6 @@ def _load_datasets(task: dict):
                     cronDatasets[cronDataset] = childCron
                 else :
                   datasets.add(dataset)
-#            _load_datasets(child)
 
 if load_dependencies.lower() != 'true' :
     if not _cron:
@@ -52,17 +63,6 @@ if load_dependencies.lower() != 'true' :
     schedule = list(map(lambda dataset: Dataset(dataset), datasets))
 
 tags = sl_job.get_context_var(var_name='tags', default_value="", options=options).split()
-
-dependencies: set = set()
-
-def load_task_dependencies(task):
-    if 'children' in task:
-        for subtask in task['children']:
-            dependencies.add(subtask['data']['name'])
-            load_task_dependencies(subtask)
-
-for task in task_deps:
-    load_task_dependencies(task)
 
 # [START instantiate_dag]
 with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", "").lower(),

--- a/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__airflow_scheduled_task_tpl.py.j2
@@ -123,8 +123,7 @@ with DAG(dag_id=os.path.basename(__file__).replace(".py", "").replace(".pyc", ""
         else:
             for child in task.get('children', []):
                 if child['data']['name'] in first_level_tasks:
-                        _children.append(child)
-                _children
+                    children.append(child)
 
         if children.__len__() > 0:
             with TaskGroup(group_id=airflow_task_group_id) as airflow_task_group:

--- a/src/main/resources/templates/dags/transform/__dagster_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__dagster_scheduled_task_tpl.py.j2
@@ -135,15 +135,13 @@ def generate_node_for_task(task, dependencies: dict, nodes: List[NodeDefinition]
     task_type = task['data']['typ']
     task_id = compute_task_id(task)
 
-    children =
-        if load_dependencies: 
-            task.get('children', [])
-        else:
-            _children = []
-            for child in task.get('children', []):
-                if child['data']['name'] in first_level_tasks:
-                    _children.append(child)
-            _children
+    children = []
+    if load_dependencies and 'children' in task: 
+        children = task['children']
+    else:
+        for child in task.get('children', []):
+            if child['data']['name'] in first_level_tasks:
+                children.append(child)
 
     if children.__len__() > 0:
 

--- a/src/main/resources/templates/dags/transform/__dagster_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__dagster_scheduled_task_tpl.py.j2
@@ -28,6 +28,8 @@ cronAssets: dict = dict()
 
 all_dependencies: set = set()
 
+_filtered_assets: Set[str] = sys.modules[__name__].__dict__.get('filtered_assets', set())
+
 def load_task_dependencies(task):
     if 'children' in task:
         for subtask in task['children']:
@@ -35,11 +37,11 @@ def load_task_dependencies(task):
             load_task_dependencies(subtask)
 
 for task in task_deps:
+    _filtered_assets.add(sanitize_id(task['data']['name']).lower())
     load_task_dependencies(task)
 
 # if you choose to not load the dependencies, a sensor will be created to check if the dependencies are met
 if not load_dependencies:
-    _filtered_assets: Set[str] = sys.modules[__name__].__dict__.get('filtered_assets', set())
 
     def load_assets(task: dict):
         if 'children' in task:

--- a/src/main/resources/templates/dags/transform/__dagster_scheduled_task_tpl.py.j2
+++ b/src/main/resources/templates/dags/transform/__dagster_scheduled_task_tpl.py.j2
@@ -30,6 +30,8 @@ all_dependencies: set = set()
 
 _filtered_assets: Set[str] = sys.modules[__name__].__dict__.get('filtered_assets', set())
 
+first_level_tasks: set = set()
+
 def load_task_dependencies(task):
     if 'children' in task:
         for subtask in task['children']:
@@ -37,6 +39,7 @@ def load_task_dependencies(task):
             load_task_dependencies(subtask)
 
 for task in task_deps:
+    first_level_tasks.add(task['data']['name'])
     _filtered_assets.add(sanitize_id(task['data']['name']).lower())
     load_task_dependencies(task)
 
@@ -132,7 +135,17 @@ def generate_node_for_task(task, dependencies: dict, nodes: List[NodeDefinition]
     task_type = task['data']['typ']
     task_id = compute_task_id(task)
 
-    if (load_dependencies and 'children' in task):
+    children =
+        if load_dependencies: 
+            task.get('children', [])
+        else:
+            _children = []
+            for child in task.get('children', []):
+                if child['data']['name'] in first_level_tasks:
+                    _children.append(child)
+            _children
+
+    if children.__len__() > 0:
 
         parent_dependencies = dict()
 


### PR DESCRIPTION
## Summary
Filter properly dag assets / datasets + to handle dependencies between first level tasks only when load_dependencies = False

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**
