### PR TITLE
fix: handle timeout exception retry

### DIFF
--- a/src/main/scala/ai/starlake/utils/GcpUtils.scala
+++ b/src/main/scala/ai/starlake/utils/GcpUtils.scala
@@ -9,6 +9,7 @@ import com.google.cloud.logging.{LogEntry, LoggingOptions}
 
 import java.util.{Collections, Locale}
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success}
 
 object GcpUtils {
   private val WELL_KNOWN_CREDENTIALS_FILE = "application_default_credentials.json"
@@ -93,7 +94,10 @@ object GcpUtils {
       // Writes the log entry asynchronously
       logging.write(Collections.singleton(entry))
       // Optional - flush any pending log entries just before Logging is closed
-      logging.flush()
+      BigQueryJobBase.recoverBigqueryException(logging.flush()) match {
+        case Failure(exception) => throw exception
+        case Success(_)         => //
+      }
     } finally if (logging != null) logging.close()
   }
 


### PR DESCRIPTION
We sometimes have the following error:

ERROR IngestionWorkflow: shade.com.google.common.base.VerifyException: java.util.concurrent.TimeoutException: Waited 6 seconds (plus 150105 nanoseconds delay) for ListFuture@642270ad[status=PENDING, info=[futures=[ApiFutureToListenableFuture{apiFuture=ListenableFutureToApiFuture{delegate=TransformFuture@439c706[status=PENDING, info=[inputFuture=[ApiFutureToListenableFuture{apiFuture=ListenableFutureToApiFuture{delegate=CatchingFuture@17e427b6[status=PENDING, info=[inputFuture=[com.google.api.core.AbstractApiFuture$InternalSettableFuture@73344f4a[status=PENDING]], exceptionType=[class com.google.api.gax.rpc.ApiException], fallback=[com.google.api.core.ApiFutures$ApiFunctionToGuavaFunction@4e4ee99]]]}}], function=[com.google.api.core.ApiFutures$ApiFunctionToGuavaFunction@4eaf08f4]]]}}]]]
at com.google.cloud.logging.LoggingImpl.flush(LoggingImpl.java:924)
2024-11-23T11:21:45.487379Z
at ai.starlake.utils.GcpUtils$.sinkToGcpCloudLogging(GcpUtils.scala:95)

It is not reproducible since it occurs on a timeout that is why this PR wraps into a retryable block.