### PR TITLE
Fix data and schema extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,11 @@ __Feature__:
 - add dynamicPartitionOverwrite sink options. Available for bigquery sink and file sink. No need to set
   spark.sql.sources.partitionOverwriteMode.
 
+__Bug fix__:
+- excluded table during data extraction defined in jdbcSchema are now taken into account
+- if column is renamed, check pattern of renamed column instead of original name since it is the target table column's name during schema extraction
+- **BREAKING CHANGE** when no fields could be inferred from input, inferred schema now fails
+
 
 __Bug Fix__:
 - **BREAKING CHANGE** the new database and tenant fields should be added to the audit table.

--- a/src/main/scala/ai/starlake/core/utils/NamingUtils.scala
+++ b/src/main/scala/ai/starlake/core/utils/NamingUtils.scala
@@ -43,20 +43,20 @@ object NamingUtils {
     *   - Replaces non-alphanumeric characters with underscores.
     *   - Replaces consecutive underscores with a single underscore.
     *   - Removes trailing and leading underscores.
-    *   - Adds underscores to camel case naming.
+    *   - Adds underscores to camel case naming if toSnakeCase is true.
     *
     * @param input
     *   The input string representing the attribute name to normalize.
     * @return
     *   A normalized string suitable for use as an attribute name.
     */
-  def normalizeAttributeName(input: String): String = {
-    addUnderscores(
-      removeTrailingUnderscore(
-        replaceConsecutiveUnderscores(
-          replaceNonAlphanumericWithUnderscore(removeAccents(input))
-        )
+  def normalizeAttributeName(input: String, toSnakeCase: Boolean = true): String = {
+    val sanitizedName = removeTrailingUnderscore(
+      replaceConsecutiveUnderscores(
+        replaceNonAlphanumericWithUnderscore(removeAccents(input))
       )
     )
+    if (toSnakeCase) addUnderscores(sanitizedName)
+    else sanitizedName
   }
 }


### PR DESCRIPTION
- excluded table during data extraction defined in jdbcSchema are now taken into account
- if column is renamed, check pattern of renamed column instead of original name since it is the target table column's name during schema extraction
- **BREAKING CHANGE** when no fields could be inferred from input, inferred schema now fails