### PR TITLE
feat: improve ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 # 1.4.0
 
+__New Feature__:
+- add the ability to have ingestion audit per input file by setting SL_DETAILED_LOAD_AUDIT to true. Useful when there is too many files that generates log entry or sql query higher than the limit.
+
 __Improvement__:
 - minimize memory usage inference-schema and adjust attributes types
 - inference-schema detects more timestamp pattern
@@ -11,6 +14,7 @@ __Improvement__:
 - **BREAKING CHANGE** flat and tree row validator have been unified and is optimized by spark
 - **BREAKING CHANGE** schema inference consider Numbers starting with 0 as String, such as for company identifier
 - **BREAKING CHANGE** schema inference consider Numbers starting with + as String, such as a telephone number
+- Move files in parallel during ingestion phase. In order to increase parallelism, set SL_MAX_PAR_COPY. Default to 1.
 
 __Miscellaneous__:
 - **BREAKING CHANGE** default value don't apply on empty string directly. It depends on the definition of emptyIsNull instead. So if emptyIsNull=true then default value is used
@@ -18,6 +22,7 @@ __Miscellaneous__:
 - revamped validation phase.
 
 __Bug fix__:
+- Fix file pattern inference when last character is not a letter or digit.
 - JSON type ingestion in bigquery are now created with JSON type instead of String.
 - excluded table during data extraction defined in jdbcSchema are now taken into account
 - if column is renamed, check pattern of renamed column instead of original name since it is the target table column's name during schema extraction

--- a/src/main/resources/reference-audit.conf
+++ b/src/main/resources/reference-audit.conf
@@ -5,6 +5,9 @@ audit {
   auditTimeout = ${?SL_LOCK_AUDIT_TIMEOUT}
   sql = "select {{ cols }}"
   maxErrors = 100
+  # detailedLoadAudit = "false" / SL_DETAILED_LOAD_AUDIT: create individual entry for each ingested file instead of a global one. Default: false
+  detailedLoadAudit = false
+  detailedLoadAudit = ${?SL_DETAILED_LOAD_AUDIT}
 
   database = ${?SL_AUDIT_DATABASE}
   domain = "audit"

--- a/src/main/resources/starlake.json
+++ b/src/main/resources/starlake.json
@@ -1338,6 +1338,10 @@
         "domainRejected": {
           "$ref": "#/definitions/ConvertibleToString"
         },
+        "detailedLoadAudit": {
+          "type": "boolean",
+          "description": "Create individual entry for each ingested file instead of a global one. Default: false"
+        },
         "active": {
           "type": "boolean",
           "description": "Output table description"

--- a/src/main/scala-2.13/ai/starlake/extract/ParUtils.scala
+++ b/src/main/scala-2.13/ai/starlake/extract/ParUtils.scala
@@ -2,12 +2,16 @@ package ai.starlake.extract
 
 import com.typesafe.scalalogging.StrictLogging
 
+import java.util.concurrent.{ExecutorService, Executors}
 import scala.collection.parallel.CollectionConverters._
 import scala.collection.parallel.ForkJoinTaskSupport
+import scala.concurrent.ExecutionContext.fromExecutor
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 object ParUtils extends StrictLogging {
   def makeParallel[T](
-    collection: List[T]
+    collection: Iterable[T]
   )(implicit fjp: Option[ForkJoinTaskSupport]) = {
     fjp match {
       case Some(pool) =>
@@ -32,6 +36,25 @@ object ParUtils extends StrictLogging {
     } else {
       val forkJoinPool = new java.util.concurrent.ForkJoinPool(maxPar)
       Some(new ForkJoinTaskSupport(forkJoinPool))
+    }
+  }
+
+  def runInParallel[T, U](parallelism: Int, collection: Iterable[T])(
+    action: T => U,
+    executor: ExecutorService = Executors.newFixedThreadPool(parallelism)
+  ): Iterable[U] = {
+    // Create a thread pool with the given parallelism level
+    implicit val ec: ExecutionContext = fromExecutor(executor)
+
+    try {
+      // Wrap each element's computation in a Future
+      val futures: Iterable[Future[U]] = collection.map(item => Future(action(item)))
+
+      // Await and return all results
+      Await.result(Future.sequence(futures), Duration.Inf)
+    } finally {
+      // Shutdown the thread pool
+      executor.shutdown()
     }
   }
 }

--- a/src/main/scala/ai/starlake/config/Settings.scala
+++ b/src/main/scala/ai/starlake/config/Settings.scala
@@ -130,7 +130,8 @@ object Settings extends StrictLogging {
     active: Option[Boolean],
     sql: Option[String],
     domainExpectation: Option[String],
-    domainRejected: Option[String]
+    domainRejected: Option[String],
+    detailedLoadAudit: Boolean
   ) {
     def isActive(): Boolean = this.active.getOrElse(false)
 

--- a/src/main/scala/ai/starlake/exceptions/StarlakeException.scala
+++ b/src/main/scala/ai/starlake/exceptions/StarlakeException.scala
@@ -1,7 +1,5 @@
 package ai.starlake.exceptions
 
-class NullValueFoundException(val nbRecord: Long)
-    extends RuntimeException(s"Found $nbRecord null values")
 class DisallowRejectRecordException() extends RuntimeException("Fail on rejected count requested")
 
 class DataExtractionException(val domain: String, val table: String)

--- a/src/main/scala/ai/starlake/job/infer/InferSchemaJob.scala
+++ b/src/main/scala/ai/starlake/job/infer/InferSchemaJob.scala
@@ -25,7 +25,6 @@ import ai.starlake.schema.handlers.{DataTypesToInt, InferSchemaHandler, StorageH
 import ai.starlake.schema.model.Format.DSV
 import ai.starlake.schema.model._
 import better.files.File
-import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
@@ -434,7 +433,7 @@ object InferSchemaJob {
       val prefixWithoutNonAlpha =
         if (
           indexOfNonAlpha != -1 &&
-          indexOfNonAlpha < prefix.length &&
+          (indexOfNonAlpha + 1) < prefix.length &&
           prefix(indexOfNonAlpha + 1).isDigit
         )
           prefix.substring(0, indexOfNonAlpha + 1) // hello-1234 => hello-
@@ -444,24 +443,5 @@ object InferSchemaJob {
       else
         s"$prefixWithoutNonAlpha.*.$extension"
     }
-  }
-  def main(args: Array[String]): Unit = {
-    val config = ConfigFactory.load()
-    implicit val settings = Settings(config, None, None)
-
-    val job = new InferSchemaJob()
-    job.infer(
-      domainName = "domain",
-      tableName = "table",
-      pattern = None,
-      comment = None,
-      // inputPath = "/Users/hayssams/Downloads/jsonarray.json",
-      inputPath = "/Users/hayssams/Downloads/ndjson-sample.json",
-      saveDir = "/Users/hayssams/tmp/aaa",
-      forceFormat = None,
-      writeMode = WriteMode.OVERWRITE,
-      rowTag = None,
-      clean = false
-    )(settings.storageHandler())
   }
 }

--- a/src/main/scala/ai/starlake/job/ingest/DummyIngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/DummyIngestionJob.scala
@@ -1,6 +1,7 @@
 package ai.starlake.job.ingest
 
 import ai.starlake.config.Settings
+import ai.starlake.job.validator.SimpleRejectedRecord
 import ai.starlake.schema.handlers.{SchemaHandler, StorageHandler}
 import ai.starlake.schema.model.{Domain, Schema, Type}
 import org.apache.hadoop.fs.Path
@@ -26,7 +27,7 @@ class DummyIngestionJob(
     *
     * @param dataset
     */
-  override protected def ingest(dataset: DataFrame): (Dataset[String], Dataset[Row], Long) =
+  override protected def ingest(dataset: DataFrame): (Dataset[SimpleRejectedRecord], Dataset[Row]) =
     throw new Exception("Should never be called. User for applying security only")
 
   override def defineOutputAsOriginalFormat(rejectedLines: DataFrame): DataFrameWriter[Row] = ???

--- a/src/main/scala/ai/starlake/job/ingest/GenericIngestionJob.scala
+++ b/src/main/scala/ai/starlake/job/ingest/GenericIngestionJob.scala
@@ -20,7 +20,6 @@
 
 package ai.starlake.job.ingest
 
-import ai.starlake.exceptions.NullValueFoundException
 import ai.starlake.config.{CometColumns, Settings}
 import ai.starlake.schema.handlers.{SchemaHandler, StorageHandler}
 import ai.starlake.schema.model._
@@ -30,7 +29,7 @@ import org.apache.spark.sql.types.StructType
 import java.sql._
 import java.time.LocalDateTime
 import java.util.Properties
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 /** Main class to ingest delimiter separated values file
   *

--- a/src/main/scala/ai/starlake/job/ingest/loaders/BigQueryNativeLoader.scala
+++ b/src/main/scala/ai/starlake/job/ingest/loaders/BigQueryNativeLoader.scala
@@ -1,7 +1,7 @@
 package ai.starlake.job.ingest.loaders
 
 import ai.starlake.config.{CometColumns, Settings}
-import ai.starlake.exceptions.NullValueFoundException
+import ai.starlake.extract.{ExtractUtils, ParUtils}
 import ai.starlake.job.ingest.{BqLoadInfo, IngestionJob}
 import ai.starlake.job.sink.bigquery.{
   BigQueryJobBase,
@@ -25,16 +25,16 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
 ) extends NativeLoader(ingestionJob, accessToken)
     with StrictLogging {
   lazy val effectiveSchema: Schema = computeEffectiveInputSchema()
-  lazy val schemaWithMergedMetadata = effectiveSchema.copy(metadata = Some(mergedMetadata))
+  lazy val schemaWithMergedMetadata: Schema = effectiveSchema.copy(metadata = Some(mergedMetadata))
 
-  lazy val targetTableId =
+  lazy val targetTableId: TableId =
     BigQueryJobBase.extractProjectDatasetAndTable(
       schemaHandler.getDatabase(domain),
       domain.finalName,
       effectiveSchema.finalName
     )
 
-  def run(): Try[IngestionCounters] = {
+  def run(): Try[List[IngestionCounters]] = {
     Try {
       val bqSink = mergedMetadata.getSink().asInstanceOf[BigQuerySink]
 
@@ -59,16 +59,16 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
           accessToken = accessToken
         )
       if (twoSteps) {
+        val startTime = System.currentTimeMillis()
         val (loadResults, tempTableIds, tableInfos) =
-          path
-            .map(_.toString)
-            .foldLeft[(List[Try[BqLoadInfo]], List[TableId], List[TableInfo])]((Nil, Nil, Nil)) {
-              case ((loadResultList, tempTableIdList, tableInfoList), sourceUri) =>
+          ParUtils
+            .runInParallel(settings.appConfig.maxParTask, path.map(_.toString).zipWithIndex) {
+              case (sourceUri, index) =>
                 val firstStepTempTable =
                   BigQueryJobBase.extractProjectDatasetAndTable(
                     schemaHandler.getDatabase(domain),
                     domain.finalName,
-                    tempTableName
+                    tempTableName + "_" + index
                   )
                 val firstStepConfig =
                   targetConfig
@@ -106,33 +106,47 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
 
                 // TODO What if type is changed by transform ? we need to use safe_cast to have the same behavior as in SPARK.
                 val firstStepResult =
-                  firstStepBigqueryJob.loadPathsToBQ(firstStepTableInfo, Some(enrichedTableInfo))
+                  firstStepBigqueryJob
+                    .loadPathsToBQ(firstStepTableInfo, Some(enrichedTableInfo))
+                (
+                  firstStepResult,
+                  firstStepTempTable,
+                  enrichedTableInfo
+                )
+            }
+            .foldLeft[(List[Try[BqLoadInfo]], List[TableId], List[TableInfo])]((Nil, Nil, Nil)) {
+              case (
+                    (loadResultList, tempTableIdList, tableInfoList),
+                    (firstStepResult, firstStepTempTable, enrichedTableInfo)
+                  ) =>
                 (
                   loadResultList :+ firstStepResult,
                   tempTableIdList :+ firstStepTempTable,
                   tableInfoList :+ enrichedTableInfo
                 )
             }
-        def combineStats(bqLoadInfo1: BqLoadInfo, bqLoadInfo2: BqLoadInfo): BqLoadInfo = {
-          BqLoadInfo(
-            bqLoadInfo1.totalAcceptedRows + bqLoadInfo2.totalAcceptedRows,
-            bqLoadInfo1.totalRejectedRows + bqLoadInfo2.totalRejectedRows,
-            jobResult = BigQueryJobResult(
-              None,
-              bqLoadInfo1.jobResult.totalBytesProcessed + bqLoadInfo2.jobResult.totalBytesProcessed,
-              None
-            )
-          )
-        }
-        val globalLoadResult: Try[BqLoadInfo] = loadResults.reduce { (result1, result2) =>
-          result1.flatMap(r => result2.map(combineStats(_, r)))
+        def tryListSequence[A](list: List[Try[A]]): Try[List[A]] = {
+          list.foldRight(Try(List.empty[A])) { (tryElem, acc) =>
+            for {
+              elem <- tryElem
+              rest <- acc
+            } yield elem :: rest
+          }
         }
 
-        val output: Try[BqLoadInfo] =
+        println("First step done in : " + ExtractUtils.toHumanElapsedTimeFrom(startTime))
+
+        val output: Try[List[BqLoadInfo]] =
           applyBigQuerySecondStep(
             targetConfig,
-            tempTableIds,
-            globalLoadResult
+            List(
+              BigQueryJobBase.extractProjectDatasetAndTable(
+                schemaHandler.getDatabase(domain),
+                domain.finalName,
+                tempTableName + "_*"
+              )
+            ),
+            tryListSequence(loadResults)
           )
 
         tempTableIds.zip(tableInfos).foreach { case (id, info) =>
@@ -141,7 +155,9 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
           val table = Option(id.getTable()).getOrElse("")
           archiveTableTask(database, schema, table, info).foreach(_.run())
         }
-        Try(tempTableIds.foreach(new BigQueryNativeJob(targetConfig, "").dropTable))
+        Try(ParUtils.runInParallel(settings.appConfig.maxParTask, tempTableIds) { tableId =>
+          new BigQueryNativeJob(targetConfig, "").dropTable(tableId)
+        })
           .flatMap(_ => output)
           .recoverWith { case exception =>
             Utils.logException(logger, exception)
@@ -149,22 +165,45 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
           } // ignore exception but log it
       } else {
         val bigqueryJob = new BigQueryNativeJob(targetConfig, "")
-        bigqueryJob.loadPathsToBQ(
-          bigqueryJob.getTableInfo(targetTableId, _.targetBqSchemaWithoutIgnore(schemaHandler))
-        )
+        bigqueryJob
+          .loadPathsToBQ(
+            bigqueryJob.getTableInfo(targetTableId, _.targetBqSchemaWithoutIgnore(schemaHandler))
+          )
+          .map(List(_))
       }
     }.map {
-      case res @ Success(result) =>
-        result.jobResult.job.flatMap(j => Option(j.getStatus.getExecutionErrors)).foreach {
-          errors =>
+      case Success(results) =>
+        results.foreach {
+          _.jobResult.job.flatMap(j => Option(j.getStatus.getExecutionErrors)).foreach { errors =>
             errors.forEach(err => logger.error(f"${err.getReason} - ${err.getMessage}"))
+          }
         }
-        IngestionCounters(
-          result.totalRows,
-          result.totalAcceptedRows,
-          result.totalRejectedRows
-        )
-      case res @ Failure(exception) =>
+        val bqLoadInfoOutput = if (settings.appConfig.audit.detailedLoadAudit) {
+          results
+        } else {
+          def combineStats(bqLoadInfo1: BqLoadInfo, bqLoadInfo2: BqLoadInfo): BqLoadInfo = {
+            BqLoadInfo(
+              totalAcceptedRows = bqLoadInfo1.totalAcceptedRows + bqLoadInfo2.totalAcceptedRows,
+              totalRejectedRows = bqLoadInfo1.totalRejectedRows + bqLoadInfo2.totalRejectedRows,
+              paths = bqLoadInfo1.paths ++ bqLoadInfo2.paths,
+              jobResult = BigQueryJobResult(
+                None,
+                bqLoadInfo1.jobResult.totalBytesProcessed + bqLoadInfo2.jobResult.totalBytesProcessed,
+                None
+              )
+            )
+          }
+          List(results.reduce(combineStats))
+        }
+        bqLoadInfoOutput.map { bli =>
+          IngestionCounters(
+            bli.totalRows,
+            bli.totalAcceptedRows,
+            bli.totalRejectedRows,
+            bli.paths
+          )
+        }
+      case Failure(exception) =>
         Utils.logException(logger, exception)
         throw exception
     }
@@ -173,11 +212,11 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
   private def applyBigQuerySecondStep(
     targetConfig: BigQueryLoadConfig,
     firstStepTempTable: List[TableId],
-    firstStepResult: Try[BqLoadInfo]
-  ): Try[BqLoadInfo] = {
+    firstStepResult: Try[List[BqLoadInfo]]
+  ): Try[List[BqLoadInfo]] = {
     firstStepResult match {
       case Success(loadFileResult) =>
-        logger.info(s"First step result: $loadFileResult")
+        logger.info(s"First step result: ${loadFileResult.map(_.toString).mkString(", ")}")
         val targetBigqueryJob = new BigQueryNativeJob(targetConfig, "")
         val secondStepResult =
           targetBigqueryJob.cliConfig.outputTableId
@@ -188,55 +227,16 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
             }
             .getOrElse(throw new Exception("Should never happen"))
 
-        def updateRejectedCount(nullCountValues: Long): Try[BqLoadInfo] = {
-          firstStepResult.map(r =>
-            r.copy(
-              totalAcceptedRows = r.totalAcceptedRows - nullCountValues,
-              totalRejectedRows = r.totalRejectedRows + nullCountValues
-            )
-          )
-        }
-
         secondStepResult
           .flatMap { _ =>
-            updateRejectedCount(0)
-          } // keep loading stats
-          .recoverWith { case ex: NullValueFoundException =>
-            updateRejectedCount(ex.nbRecord)
+            firstStepResult
           }
       case res @ Failure(_) =>
         res
     }
   }
 
-  private def getArchiveTableComponents(): (Option[String], String, String) = {
-    val fullArchiveTableName = Utils.parseJinja(
-      settings.appConfig.archiveTablePattern,
-      Map("domain" -> domain.finalName, "table" -> starlakeSchema.finalName)
-    )
-    val archiveTableComponents = fullArchiveTableName.split('.')
-    val (archiveDatabaseName, archiveDomainName, archiveTableName) =
-      if (archiveTableComponents.length == 3) {
-        (
-          Some(archiveTableComponents(0)),
-          archiveTableComponents(1),
-          archiveTableComponents(2)
-        )
-      } else if (archiveTableComponents.length == 2) {
-        (
-          schemaHandler.getDatabase(domain),
-          archiveTableComponents(0),
-          archiveTableComponents(1)
-        )
-      } else {
-        throw new Exception(
-          s"Archive table name must be in the format <domain>.<table> but got $fullArchiveTableName"
-        )
-      }
-    (archiveDatabaseName, archiveDomainName, archiveTableName)
-  }
-
-  def applyBigQuerySecondStepSQL(
+  private def applyBigQuerySecondStepSQL(
     firstStepTempTableTableNames: List[String]
   ): Try[JobResult] = {
     val task = this.secondStepSQLTask(firstStepTempTableTableNames)

--- a/src/main/scala/ai/starlake/job/ingest/loaders/DuckDbNativeLoader.scala
+++ b/src/main/scala/ai/starlake/job/ingest/loaders/DuckDbNativeLoader.scala
@@ -48,7 +48,7 @@ class DuckDbNativeLoader(ingestionJob: IngestionJob)(implicit
   lazy val effectiveSchema: Schema = computeEffectiveInputSchema()
   lazy val schemaWithMergedMetadata = effectiveSchema.copy(metadata = Some(mergedMetadata))
 
-  def run(): Try[IngestionCounters] = {
+  def run(): Try[List[IngestionCounters]] = {
     Try {
       val sinkConnection = mergedMetadata.getSinkConnection()
       val twoSteps = requireTwoSteps(effectiveSchema)
@@ -121,7 +121,7 @@ class DuckDbNativeLoader(ingestionJob: IngestionJob)(implicit
         singleStepLoad(domain.finalName, schema.finalName, schemaWithMergedMetadata, path)
       }
     }.map { - =>
-      IngestionCounters(-1, -1, -1)
+      List(IngestionCounters(-1, -1, -1, path.map(_.toString)))
     }
   }
 

--- a/src/main/scala/ai/starlake/job/ingest/loaders/NativeLoader.scala
+++ b/src/main/scala/ai/starlake/job/ingest/loaders/NativeLoader.scala
@@ -58,7 +58,7 @@ class NativeLoader(ingestionJob: IngestionJob, accessToken: Option[String])(impl
       .hasTransformOrIgnoreOrScriptColumns() ||
     strategy.isMerge() ||
     schema.filter.nonEmpty ||
-    settings.appConfig.archiveTable
+    settings.appConfig.archiveTable || settings.appConfig.audit.detailedLoadAudit && path.size > 1
   }
 
   val twoSteps: Boolean = requireTwoSteps(starlakeSchema)
@@ -318,7 +318,7 @@ class NativeLoader(ingestionJob: IngestionJob, accessToken: Option[String])(impl
   def auditStatements(): Option[TaskSQLStatements] = {
     if (settings.appConfig.audit.active.getOrElse(true)) {
       val auditStatements =
-        AuditLog.buildListOfSQLStatements(auditLog)(settings, storageHandler, schemaHandler)
+        AuditLog.buildListOfSQLStatements(List(auditLog))(settings, storageHandler, schemaHandler)
       auditStatements
     } else {
       None

--- a/src/main/scala/ai/starlake/job/metrics/ExpectationJob.scala
+++ b/src/main/scala/ai/starlake/job/metrics/ExpectationJob.scala
@@ -220,9 +220,11 @@ class ExpectationJob(
         auditSink.getConnectionType() match {
           case ConnectionType.GCPLOG =>
             val logName = settings.appConfig.audit.getDomainExpectation()
-            expectationReports.foreach { log =>
-              GcpUtils.sinkToGcpCloudLogging(log.asMap(), "expectation", logName)
-            }
+            GcpUtils.sinkToGcpCloudLogging(
+              expectationReports.map(_.asMap()),
+              "expectation",
+              logName
+            )
             Success(new JobResult {})
           case _ =>
             val sqls = expectationReports

--- a/src/main/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJob.scala
+++ b/src/main/scala/ai/starlake/job/sink/bigquery/BigQuerySparkJob.scala
@@ -241,7 +241,7 @@ class BigQuerySparkJob(
         updateColumnsDescription(BigQueryJobBase.dictToBQSchema(attributesDescMap))
       // TODO verify if there is a difference between maybeTableDescription, schema.comment , task.desc
       updateTableDescription(table, maybeTableDescription.getOrElse(""))
-      output.map(rejected => SparkJobResult(None, Some(IngestionCounters(0, 0, rejected))))
+      output.map(rejected => SparkJobResult(None, Some(IngestionCounters(0, 0, rejected, Nil))))
     }
   }
 

--- a/src/main/scala/ai/starlake/job/transform/AutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/AutoTask.scala
@@ -299,12 +299,12 @@ abstract class AutoTask(
     test: Boolean
   ): Unit = {
     val log = auditLog(start, end, jobResultCount, success = true, "success", test)
-    log.foreach(AuditLog.sink)
+    log.foreach(al => AuditLog.sink(List(al)))
   }
 
   def logAuditFailure(start: Timestamp, end: Timestamp, e: Throwable, test: Boolean): Unit = {
     val log = auditLog(start, end, -1, success = false, Utils.exceptionAsString(e), test)
-    log.foreach(AuditLog.sink)
+    log.foreach(al => AuditLog.sink(List(al)))
   }
 
   def dependencies(streams: CaseInsensitiveMap[String]): List[String] = {
@@ -384,7 +384,7 @@ abstract class AutoTask(
           success = true,
           "success",
           test
-        ).flatMap(AuditLog.buildListOfSQLStatements)
+        ).flatMap(al => AuditLog.buildListOfSQLStatements(List(al)))
       auditStatements
     } else {
       None

--- a/src/main/scala/ai/starlake/job/transform/BigQueryAutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/BigQueryAutoTask.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.types.StructType
 
 import java.sql.Timestamp
 import java.time.Instant
-import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/ai/starlake/job/validator/AcceptAllValidator.scala
+++ b/src/main/scala/ai/starlake/job/validator/AcceptAllValidator.scala
@@ -23,7 +23,7 @@ object AcceptAllValidator extends GenericRowValidator {
     rejectWithValue: Boolean
   )(implicit schemaHandler: SchemaHandler): CheckValidityResult = {
     import session.implicits._
-    val rejectedDS = session.emptyDataset[String]
+    val rejectedDS = session.emptyDataset[SimpleRejectedRecord]
     val rejectedInputDS = session.emptyDataFrame
     val validator = new RowValidator(
       attributes,

--- a/src/main/scala/ai/starlake/job/validator/FlatRowValidator.scala
+++ b/src/main/scala/ai/starlake/job/validator/FlatRowValidator.scala
@@ -44,9 +44,10 @@ object FlatRowValidator extends GenericRowValidator {
             lit("\n\nFILE -> "),
             col(CometColumns.cometInputFileNameColumn)
           )
-          .as("errors")
+          .as("errors"),
+        col(CometColumns.cometInputFileNameColumn).as("path")
       )
-      .as[String]
+      .as[SimpleRejectedRecord]
 
     CheckValidityResult(
       formattedRejectedDF.persist(cacheStorageLevel),

--- a/src/main/scala/ai/starlake/job/validator/GenericRowValidator.scala
+++ b/src/main/scala/ai/starlake/job/validator/GenericRowValidator.scala
@@ -7,7 +7,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.storage.StorageLevel
 
 case class CheckValidityResult(
-  errors: Dataset[String],
+  errors: Dataset[SimpleRejectedRecord],
   rejected: Dataset[Row],
   accepted: Dataset[Row]
 )

--- a/src/main/scala/ai/starlake/job/validator/NativeValidator.scala
+++ b/src/main/scala/ai/starlake/job/validator/NativeValidator.scala
@@ -24,7 +24,7 @@ object NativeValidator extends GenericRowValidator {
     rejectWithValue: Boolean
   )(implicit schemaHandler: SchemaHandler): CheckValidityResult = {
     import session.implicits._
-    val rejectedDS = session.emptyDataset[String]
+    val rejectedDS = session.emptyDataset[SimpleRejectedRecord]
     val rejectedInputDS = session.emptyDataFrame
     val acceptedDS = dataset
     CheckValidityResult(rejectedDS, rejectedInputDS, acceptedDS)

--- a/src/main/scala/ai/starlake/job/validator/SimpleRejectedRecord.scala
+++ b/src/main/scala/ai/starlake/job/validator/SimpleRejectedRecord.scala
@@ -1,0 +1,3 @@
+package ai.starlake.job.validator
+
+case class SimpleRejectedRecord(errors: String, path: String)

--- a/src/main/scala/ai/starlake/job/validator/TreeRowValidator.scala
+++ b/src/main/scala/ai/starlake/job/validator/TreeRowValidator.scala
@@ -37,14 +37,17 @@ object TreeRowValidator extends GenericRowValidator {
 
     val formattedRejectedDF = rejectedDF
       .select(
-        functions.concat(
-          lit("ERR -> \n"),
-          concat_ws("\n", col(RowValidator.SL_ERROR_COL)),
-          lit("\n\nFILE -> "),
-          col(CometColumns.cometInputFileNameColumn)
-        )
+        functions
+          .concat(
+            lit("ERR -> \n"),
+            concat_ws("\n", col(RowValidator.SL_ERROR_COL)),
+            lit("\n\nFILE -> "),
+            col(CometColumns.cometInputFileNameColumn)
+          )
+          .as("errors"),
+        col(CometColumns.cometInputFileNameColumn).as("path")
       )
-      .as[String]
+      .as[SimpleRejectedRecord]
 
     CheckValidityResult(
       formattedRejectedDF.persist(cacheStorageLevel),

--- a/src/main/scala/ai/starlake/schema/handlers/HdfsStorageHandler.scala
+++ b/src/main/scala/ai/starlake/schema/handlers/HdfsStorageHandler.scala
@@ -28,6 +28,7 @@ import org.apache.hadoop.io.compress.CompressionCodecFactory
 import org.apache.spark.sql.execution.streaming.FileStreamSource.Timestamp
 
 import java.io._
+import java.net.URI
 import java.nio.charset.{Charset, StandardCharsets}
 import java.time.{Instant, LocalDateTime, ZoneId}
 import java.util.regex.Pattern
@@ -188,16 +189,13 @@ class HdfsStorageHandler(fileSystem: String)(implicit
     conf
   }
 
-  val GCSUriRegEx = "(.*)://(.*?)/(.*)".r
-
-  private def extracSchemeAndBucketAndFilePath(uri: String): (String, Option[String], String) =
-    uri match {
-      case GCSUriRegEx("file", bucketName, filePath) =>
-        ("file", None, "/" + filePath)
-      case GCSUriRegEx(scheme, bucketName, filePath) =>
-        (scheme, Some(bucketName), filePath)
-      case _ => (defaultFS.getScheme, None, uri)
+  private def extracSchemeAndBucketAndFilePath(uri: URI): (String, Option[String], String) = {
+    uri.getScheme match {
+      case "file" =>
+        (uri.getScheme, None, "/" + uri.getPath)
+      case _ => (uri.getScheme, Option(uri.getHost), uri.getPath)
     }
+  }
 
   private def normalizedFileSystem(fileSystem: String): String = {
     if (fileSystem.endsWith(":"))
@@ -226,7 +224,7 @@ class HdfsStorageHandler(fileSystem: String)(implicit
     val path =
       if (inputPath.toString.contains(':')) inputPath
       else new Path(settings.appConfig.fileSystem, inputPath.toString)
-    val (scheme, bucketOpt, _) = extracSchemeAndBucketAndFilePath(path.toString)
+    val (scheme, bucketOpt, _) = extracSchemeAndBucketAndFilePath(path.toUri)
     val fs = scheme match {
       case "gs" | "s3" | "s3a" | "s3n" =>
         bucketOpt match {
@@ -238,6 +236,9 @@ class HdfsStorageHandler(fileSystem: String)(implicit
               "Using gs/s3 scheme must be with a bucket name. gs://bucketName"
             )
         }
+      case "file" =>
+        conf.set("fs.defaultFS", "file:///")
+        FileSystem.get(conf)
       case _ => defaultFS
     }
     fs.setWriteChecksum(false)
@@ -425,16 +426,25 @@ class HdfsStorageHandler(fileSystem: String)(implicit
     */
   def move(src: Path, dst: Path): Boolean = {
     pathSecurityCheck(src)
-    val currentFS = fs(src)
-    delete(dst)
-    dst.getParent.toString.split("://") match {
-      case Array(_, path) =>
-        if (path.split("/").count(_.nonEmpty) > 1)
-          mkdirs(dst.getParent)
-      case _ =>
-        mkdirs(dst.getParent) // local file system
+    val destFS = fs(dst)
+    val sourceFS = fs(src)
+    val destURI = destFS.getUri
+    val sourceURI = sourceFS.getUri
+    if (sourceURI.getScheme == destURI.getScheme && sourceURI.getHost == destURI.getHost) {
+      delete(dst)
+      mkdirs(dst.getParent)
+      sourceFS.rename(src, dst)
+    } else {
+      delete(dst)
+      dst.getParent.toString.split("://") match {
+        case Array(_, path) =>
+          if (path.split("/").count(_.nonEmpty) > 1)
+            mkdirs(dst.getParent)
+        case _ =>
+          mkdirs(dst.getParent) // local file system
+      }
+      FileUtil.copy(fs(src), src, fs(dst), dst, true, conf)
     }
-    FileUtil.copy(fs(src), src, fs(dst), dst, true, conf)
   }
 
   /** delete file (skip trash)

--- a/src/main/scala/ai/starlake/utils/Job.scala
+++ b/src/main/scala/ai/starlake/utils/Job.scala
@@ -11,7 +11,12 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
-case class IngestionCounters(inputCount: Long, acceptedCount: Long, rejectedCount: Long) {
+case class IngestionCounters(
+  inputCount: Long,
+  acceptedCount: Long,
+  rejectedCount: Long,
+  paths: List[String]
+) {
   def ignore: Boolean = inputCount == -1 && rejectedCount == -1 && acceptedCount == -1
   override def toString() = {
     s"""Load summary:

--- a/src/main/scala/ai/starlake/utils/conversion/BigQueryUtils.scala
+++ b/src/main/scala/ai/starlake/utils/conversion/BigQueryUtils.scala
@@ -146,8 +146,8 @@ object BigQueryUtils {
     (tableId.getProject, tableId.getDataset, tableId.getTable) match {
       case (null, null, null)        => ""
       case (null, null, table)       => table
-      case (null, dataset, table)    => s"$dataset.$table"
-      case (project, dataset, table) => s"`$project`.$dataset.$table"
+      case (null, dataset, table)    => s"`$dataset`.`$table`"
+      case (project, dataset, table) => s"`$project`.`$dataset`.`$table`"
     }
   }
 }

--- a/src/main/scala/ai/starlake/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/ai/starlake/workflow/IngestionWorkflow.scala
@@ -21,7 +21,7 @@
 package ai.starlake.workflow
 
 import ai.starlake.config.{DatasetArea, Settings}
-import ai.starlake.extract.ParUtils
+import ai.starlake.extract.{ExtractUtils, ParUtils}
 import ai.starlake.job.infer.{InferSchemaConfig, InferSchemaJob}
 import ai.starlake.job.ingest._
 import ai.starlake.job.load.LoadStrategy
@@ -63,7 +63,9 @@ import org.apache.hadoop.fs.Path
 import java.nio.file.{FileSystems, ProviderNotFoundException}
 import java.time.Instant
 import java.util.Collections
+import java.util.concurrent.Executors
 import scala.annotation.nowarn
+import scala.concurrent.duration.Duration
 import scala.reflect.io.Directory
 import scala.util.{Failure, Success, Try}
 
@@ -462,17 +464,27 @@ class IngestionWorkflow(
 
                   // We group by groupedMax to avoid rateLimit exceeded when the number of grouped files is too big for some cloud storage rate limitations.
                   val groupedPendingPathsIterator =
-                    pendingPaths.grouped(settings.appConfig.groupedMax)
+                    pendingPaths.grouped(settings.appConfig.groupedMax).toList
+                  val startTime = System.currentTimeMillis()
+                  val groupedPendingSize = groupedPendingPathsIterator.size
                   groupedPendingPathsIterator.flatMap { pendingPaths =>
-                    val ingestingPaths = pendingPaths.map { pendingPath =>
-                      val ingestingPath =
-                        new Path(DatasetArea.ingesting(domain.name), pendingPath.path.getName)
-                      if (!storageHandler.move(pendingPath.path, ingestingPath)) {
-                        logger.error(s"Could not move $pendingPath to $ingestingPath")
+                    // Move files concurrently using Future
+                    val ingestingPaths =
+                      ParUtils.runInParallel(settings.appConfig.maxParCopy, pendingPaths) {
+                        pendingPath =>
+                          val ingestingPath =
+                            new Path(
+                              DatasetArea.ingesting(domain.name),
+                              pendingPath.path.getName
+                            )
+                          if (!storageHandler.move(pendingPath.path, ingestingPath)) {
+                            logger.error(s"Could not move $pendingPath to $ingestingPath")
+                          }
+                          ingestingPath
                       }
-                      ingestingPath
-                    }
-                    val jobs = if (settings.appConfig.grouped) {
+
+                    // Wait for all moves to complete
+                    val jobs: Iterable[JobContext] = if (settings.appConfig.grouped) {
                       JobContext(
                         domain,
                         schema,
@@ -481,26 +493,32 @@ class IngestionWorkflow(
                         config.accessToken
                       ) :: Nil
                     } else {
-                      // We ingest all the files but return false if one of them fails.
                       ingestingPaths.map { path =>
-                        JobContext(domain, schema, path :: Nil, config.options, config.accessToken)
+                        JobContext(
+                          domain,
+                          schema,
+                          path :: Nil,
+                          config.options,
+                          config.accessToken
+                        )
                       }
                     }
-                    implicit val forkJoinTaskSupport =
-                      ParUtils.createForkSupport(Some(settings.appConfig.sparkScheduling.maxJobs))
-                    val parJobs =
-                      ParUtils.makeParallel(jobs.toList)
-                    val res = parJobs.map { jobContext =>
-                      ingest(
-                        jobContext.domain,
-                        jobContext.schema,
-                        jobContext.paths,
-                        jobContext.options,
-                        jobContext.accessToken,
-                        config.test
-                      )
-                    }.toList
-                    forkJoinTaskSupport.foreach(_.forkJoinPool.shutdown())
+                    val moveDuration = System.currentTimeMillis() - startTime
+                    println("Grouped pending paths number = " + groupedPendingSize)
+                    println("Moved files number = " + pendingPaths.size)
+                    println("duration " + ExtractUtils.toHumanElapsedTime(moveDuration))
+                    val res =
+                      ParUtils.runInParallel(settings.appConfig.sparkScheduling.maxJobs, jobs) {
+                        jobContext =>
+                          ingest(
+                            jobContext.domain,
+                            jobContext.schema,
+                            jobContext.paths,
+                            jobContext.options,
+                            jobContext.accessToken,
+                            config.test
+                          )
+                      }
                     res
                   }
                 }
@@ -523,16 +541,17 @@ class IngestionWorkflow(
       successLoads
         .flatMap {
           case Success(result: SparkJobResult) =>
-            Some(result.counters.getOrElse(IngestionCounters(0, 0, 0)))
+            Some(result.counters.getOrElse(IngestionCounters(0, 0, 0, Nil)))
           case Success(_) => None
         }
 
     val counters =
-      successAsJobResult.fold(IngestionCounters(0, 0, 0)) { (acc, c) =>
+      successAsJobResult.fold(IngestionCounters(0, 0, 0, Nil)) { (acc, c) =>
         IngestionCounters(
           acc.inputCount + c.inputCount,
           acc.acceptedCount + c.acceptedCount,
-          acc.rejectedCount + c.rejectedCount
+          acc.rejectedCount + c.rejectedCount,
+          acc.paths ++ c.paths
         )
       }
     if (exceptionsAsString.nonEmpty) {
@@ -675,7 +694,7 @@ class IngestionWorkflow(
   def ingest(
     domain: Domain,
     schema: Schema,
-    ingestingPath: List[Path],
+    ingestingPaths: List[Path],
     options: Map[String, String],
     accessToken: Option[String],
     test: Boolean
@@ -684,7 +703,7 @@ class IngestionWorkflow(
     Utils.println(
       s"""Loading
          |Format: ${metadata.resolveFormat()}
-         |File(s): ${ingestingPath.mkString(",")}
+         |File(s): ${ingestingPaths.mkString(",")}
          |Table: ${domain.finalName}.${schema.finalName}""".stripMargin
     )
     logger.debug(
@@ -699,7 +718,7 @@ class IngestionWorkflow(
             domain,
             schema,
             schemaHandler.types(),
-            ingestingPath,
+            ingestingPaths,
             storageHandler,
             schemaHandler,
             optionsAndEnvVars,
@@ -711,7 +730,7 @@ class IngestionWorkflow(
             domain,
             schema,
             schemaHandler.types(),
-            ingestingPath,
+            ingestingPaths,
             storageHandler,
             schemaHandler,
             optionsAndEnvVars,
@@ -723,7 +742,7 @@ class IngestionWorkflow(
             domain,
             schema,
             schemaHandler.types(),
-            ingestingPath,
+            ingestingPaths,
             storageHandler,
             schemaHandler,
             optionsAndEnvVars,
@@ -735,7 +754,7 @@ class IngestionWorkflow(
             domain,
             schema,
             schemaHandler.types(),
-            ingestingPath,
+            ingestingPaths,
             storageHandler,
             schemaHandler,
             optionsAndEnvVars,
@@ -747,7 +766,7 @@ class IngestionWorkflow(
             domain,
             schema,
             schemaHandler.types(),
-            ingestingPath,
+            ingestingPaths,
             storageHandler,
             schemaHandler,
             optionsAndEnvVars,
@@ -759,7 +778,7 @@ class IngestionWorkflow(
             domain,
             schema,
             schemaHandler.types(),
-            ingestingPath,
+            ingestingPaths,
             storageHandler,
             schemaHandler,
             optionsAndEnvVars,
@@ -771,7 +790,7 @@ class IngestionWorkflow(
             domain,
             schema,
             schemaHandler.types(),
-            ingestingPath,
+            ingestingPaths,
             storageHandler,
             schemaHandler,
             optionsAndEnvVars,
@@ -783,7 +802,7 @@ class IngestionWorkflow(
             domain,
             schema,
             schemaHandler.types(),
-            ingestingPath,
+            ingestingPaths,
             storageHandler,
             schemaHandler,
             optionsAndEnvVars,
@@ -796,7 +815,7 @@ class IngestionWorkflow(
             domain,
             schema,
             schemaHandler.types(),
-            ingestingPath,
+            ingestingPaths,
             storageHandler,
             schemaHandler,
             optionsAndEnvVars,
@@ -813,20 +832,19 @@ class IngestionWorkflow(
         if (test) {
           logger.info(s"Test mode enabled, no file will be deleted")
         } else if (settings.appConfig.archive) {
-          implicit val forkJoinTaskSupport =
-            ParUtils.createForkSupport(Some(settings.appConfig.maxParCopy))
-          val parIngests =
-            ParUtils.makeParallel(ingestingPath)
-          parIngests.foreach { ingestingPath =>
+          val now = System.currentTimeMillis()
+          ParUtils.runInParallel(settings.appConfig.maxParCopy, ingestingPaths) { ingestingPath =>
             val archivePath =
               new Path(DatasetArea.archive(domain.name), ingestingPath.getName)
             logger.info(s"Backing up file $ingestingPath to $archivePath")
             val _ = storageHandler.move(ingestingPath, archivePath)
           }
-          forkJoinTaskSupport.foreach(_.forkJoinPool.shutdown())
+          println("Archive duration takes " + ExtractUtils.toHumanElapsedTimeFrom(now))
         } else {
-          logger.info(s"Deleting file $ingestingPath")
-          ingestingPath.foreach(storageHandler.delete)
+          logger.info(s"Deleting file $ingestingPaths")
+          ParUtils.runInParallel(settings.appConfig.maxParCopy, ingestingPaths) { ingestingPath =>
+            storageHandler.delete(ingestingPath)
+          }
         }
         Success(jobResult)
       case Success(Failure(exception)) =>

--- a/src/test/scala/ai/starlake/schema/generator/YamlSerdeSpec.scala
+++ b/src/test/scala/ai/starlake/schema/generator/YamlSerdeSpec.scala
@@ -1064,6 +1064,7 @@ object YamlConfigGenerators {
       sql               <- Gen.option(arbitrary[String])
       domainExpectation <- Gen.option(arbitrary[String])
       domainRejected    <- Gen.option(arbitrary[String])
+      detailedLoadAudit <- arbitrary[Boolean]
     } yield Audit(
       path = path,
       sink = sink,
@@ -1073,7 +1074,8 @@ object YamlConfigGenerators {
       active = active,
       sql = sql,
       domainExpectation = domainExpectation,
-      domainRejected = domainRejected
+      domainRejected = domainRejected,
+      detailedLoadAudit = detailedLoadAudit
     )
   }
 


### PR DESCRIPTION
Move files in parallel during ingestion phase. In order to increase parallelism, set SL_MAX_PAR_COPY. Default to 1.

Add the ability to have ingestion audit per input file by setting SL_DETAILED_LOAD_AUDIT to true. Useful when there is too many files that generates log entry or sql query higher than the limit.

Fix an out of bound on inferred pattern name.