### PR TITLE
feat: add encoding option to schema inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ __Improvement__:
 - **BREAKING CHANGE** schema inference consider Numbers starting with 0 as String, such as for company identifier
 - **BREAKING CHANGE** schema inference consider Numbers starting with + as String, such as a telephone number
 - Move files in parallel during ingestion phase. In order to increase parallelism, set SL_MAX_PAR_COPY. Default to 1.
+- add encoding option to schema-inference
 
 __Miscellaneous__:
 - **BREAKING CHANGE** default value don't apply on empty string directly. It depends on the definition of emptyIsNull instead. So if emptyIsNull=true then default value is used

--- a/src/main/scala/ai/starlake/job/infer/InferSchemaCmd.scala
+++ b/src/main/scala/ai/starlake/job/infer/InferSchemaCmd.scala
@@ -9,6 +9,7 @@ import better.files.File
 import com.typesafe.scalalogging.StrictLogging
 import scopt.OParser
 
+import java.nio.charset.Charset
 import scala.util.{Failure, Success, Try}
 
 object InferSchemaCmd extends Cmd[InferSchemaConfig] with StrictLogging {
@@ -58,7 +59,12 @@ object InferSchemaCmd extends Cmd[InferSchemaConfig] with StrictLogging {
         .opt[Unit]("clean")
         .action((_, c) => c.copy(clean = true))
         .optional()
-        .text("Delete previous YML before writing")
+        .text("Delete previous YML before writing"),
+      builder
+        .opt[String]("encoding")
+        .action((x, c) => c.copy(encoding = Charset.forName(x)))
+        .optional()
+        .text("Input file encoding. Default to UTF-8")
     )
   }
 

--- a/src/main/scala/ai/starlake/job/infer/InferSchemaConfig.scala
+++ b/src/main/scala/ai/starlake/job/infer/InferSchemaConfig.scala
@@ -22,6 +22,7 @@ package ai.starlake.job.infer
 import ai.starlake.schema.model.{Format, WriteMode}
 import better.files.File
 
+import java.nio.charset.{Charset, StandardCharsets}
 import java.util.regex.Pattern
 
 case class InferSchemaConfig(
@@ -32,7 +33,8 @@ case class InferSchemaConfig(
   format: Option[Format] = None,
   write: Option[WriteMode] = None,
   rowTag: Option[String] = None,
-  clean: Boolean = false
+  clean: Boolean = false,
+  encoding: Charset = StandardCharsets.UTF_8
 ) {
   def extractTableNameAndWriteMode(): (String, WriteMode) = {
     val file: File = File(inputPath)

--- a/src/main/scala/ai/starlake/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/ai/starlake/schema/handlers/InferSchemaHandler.scala
@@ -57,6 +57,7 @@ import org.apache.spark.sql.types.{
   TimestampType
 }
 
+import java.nio.charset.Charset
 import java.time.format.DateTimeFormatter
 import java.util.regex.Pattern
 import scala.util.Try
@@ -566,6 +567,7 @@ object InferSchemaHandler extends StrictLogging {
 
   def createMetaData(
     format: Format,
+    encoding: Charset,
     array: Option[Boolean] = None,
     withHeader: Option[Boolean] = None,
     separator: Option[String] = None,
@@ -573,7 +575,7 @@ object InferSchemaHandler extends StrictLogging {
   ): Metadata =
     Metadata(
       format = Some(format),
-      encoding = None,
+      encoding = Some(encoding.name()),
       multiline = None,
       array = if (array.contains(true)) array else None,
       withHeader = withHeader,

--- a/src/main/scala/ai/starlake/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/ai/starlake/workflow/IngestionWorkflow.scala
@@ -63,9 +63,7 @@ import org.apache.hadoop.fs.Path
 import java.nio.file.{FileSystems, ProviderNotFoundException}
 import java.time.Instant
 import java.util.Collections
-import java.util.concurrent.Executors
 import scala.annotation.nowarn
-import scala.concurrent.duration.Duration
 import scala.reflect.io.Directory
 import scala.util.{Failure, Success, Try}
 
@@ -885,7 +883,8 @@ class IngestionWorkflow(
       forceFormat = config.format,
       writeMode = config.write.getOrElse(write),
       rowTag = config.rowTag,
-      clean = config.clean
+      clean = config.clean,
+      encoding = config.encoding
     )(settings.storageHandler())
     Utils.logFailure(result, logger)
     result

--- a/src/test/scala/ai/starlake/job/infer/InferSchemaSpec.scala
+++ b/src/test/scala/ai/starlake/job/infer/InferSchemaSpec.scala
@@ -18,6 +18,7 @@ class InferSchemaSpec extends TestHelper {
           |  --format <value>       Force input file format
           |  --rowTag <value>       row tag to use if detected format is XML
           |  --clean                Delete previous YML before writing
+          |  --encoding <value>     Input file encoding. Default to UTF-8
           |""".stripMargin
       rendered.substring(rendered.indexOf("Usage:")).replaceAll("\\s", "") shouldEqual expected
         .replaceAll("\\s", "")

--- a/src/test/scala/ai/starlake/schema/handlers/InferSchemaJobSpec.scala
+++ b/src/test/scala/ai/starlake/schema/handlers/InferSchemaJobSpec.scala
@@ -7,13 +7,14 @@ import ai.starlake.utils.{Utils, YamlSerde}
 import better.files.File
 import org.apache.hadoop.fs.Path
 
+import java.nio.charset.StandardCharsets
 import scala.io.Source
 
 class InferSchemaJobSpec extends TestHelper {
 
   new WithSettings() {
 
-    implicit val storageHandlerImpl = settings.storageHandler()
+    implicit val storageHandlerImpl: StorageHandler = settings.storageHandler()
 
     lazy val csvLines =
       Utils.withResources(Source.fromFile("src/test/resources/sample/SCHEMA-VALID-NOHEADER.dsv"))(
@@ -67,27 +68,36 @@ class InferSchemaJobSpec extends TestHelper {
 
     "GetFormatCSV" should "succeed" in {
       inferSchemaJob.getFormatFile(
-        "src/test/resources/sample/SCHEMA-VALID-NOHEADER.dsv"
+        "src/test/resources/sample/SCHEMA-VALID-NOHEADER.dsv",
+        StandardCharsets.UTF_8
       ) shouldBe "DSV"
     }
 
     "GetFormatJson" should "succeed" in {
-      inferSchemaJob.getFormatFile("src/test/resources/sample/json/complex.json") shouldBe "JSON"
+      inferSchemaJob.getFormatFile(
+        "src/test/resources/sample/json/complex.json",
+        StandardCharsets.UTF_8
+      ) shouldBe "JSON"
     }
 
     "GetFormatXML" should "succeed" in {
-      inferSchemaJob.getFormatFile("src/test/resources/sample/xml/locations.xml") shouldBe "XML"
+      inferSchemaJob.getFormatFile(
+        "src/test/resources/sample/xml/locations.xml",
+        StandardCharsets.UTF_8
+      ) shouldBe "XML"
     }
 
     "GetFormatArrayJson" should "succeed" in {
       inferSchemaJob.getFormatFile(
-        "src/test/resources/quickstart/incoming/hr/sellers-2018-01-01.json"
+        "src/test/resources/quickstart/incoming/hr/sellers-2018-01-01.json",
+        StandardCharsets.UTF_8
       ) shouldBe "JSON_ARRAY"
     }
 
     "GetFormatArrayJsonMultiline" should "succeed" in {
       inferSchemaJob.getFormatFile(
-        "src/test/resources/sample/simple-json-locations/locations.json"
+        "src/test/resources/sample/simple-json-locations/locations.json",
+        StandardCharsets.UTF_8
       ) shouldBe "JSON_ARRAY"
     }
     "Ingest Flat Locations JSON" should "produce file in accepted" in {
@@ -119,6 +129,7 @@ class InferSchemaJobSpec extends TestHelper {
               forceFormat = None,
               writeMode = WriteMode.OVERWRITE,
               rowTag = None,
+              encoding = StandardCharsets.UTF_8,
               clean = false
             )(settings.storageHandler())
           val locationDir = File(targetDir, "locations")
@@ -174,6 +185,7 @@ class InferSchemaJobSpec extends TestHelper {
             forceFormat = None,
             writeMode = WriteMode.OVERWRITE,
             rowTag = None,
+            encoding = StandardCharsets.UTF_8,
             clean = false
           )(settings.storageHandler())
           val locationDir = File(targetDir, "locations")
@@ -234,6 +246,7 @@ class InferSchemaJobSpec extends TestHelper {
             forceFormat = None,
             writeMode = WriteMode.OVERWRITE,
             rowTag = None,
+            encoding = StandardCharsets.UTF_8,
             clean = false
           )(settings.storageHandler())
           val locationDir = File(targetDir, "locations")
@@ -276,6 +289,7 @@ class InferSchemaJobSpec extends TestHelper {
             forceFormat = None,
             writeMode = WriteMode.OVERWRITE,
             rowTag = None,
+            encoding = StandardCharsets.UTF_8,
             clean = false
           )(settings.storageHandler())
           val locationDir = File(targetDir, "json")
@@ -303,6 +317,7 @@ class InferSchemaJobSpec extends TestHelper {
             forceFormat = None,
             writeMode = WriteMode.OVERWRITE,
             rowTag = None,
+            encoding = StandardCharsets.UTF_8,
             clean = false
           )(settings.storageHandler())
           val locationDir = File(targetDir, "json")
@@ -330,6 +345,7 @@ class InferSchemaJobSpec extends TestHelper {
             forceFormat = None,
             writeMode = WriteMode.OVERWRITE,
             rowTag = None,
+            encoding = StandardCharsets.UTF_8,
             clean = false
           )(settings.storageHandler())
           val locationDir = File(targetDir, "json")
@@ -357,6 +373,7 @@ class InferSchemaJobSpec extends TestHelper {
             forceFormat = None,
             writeMode = WriteMode.OVERWRITE,
             rowTag = None,
+            encoding = StandardCharsets.UTF_8,
             clean = false
           )(settings.storageHandler())
           val locationDir = File(targetDir, "json")
@@ -393,6 +410,7 @@ class InferSchemaJobSpec extends TestHelper {
             forceFormat = None,
             writeMode = WriteMode.OVERWRITE,
             rowTag = None,
+            encoding = StandardCharsets.UTF_8,
             clean = false
           )(settings.storageHandler())
           val locationDir = File(targetDir, "parquet")


### PR DESCRIPTION
Currently, infer-schema suppose input file to be encoded as utf-8, making it impossible to infer some files when encoding is like cp1252.

Add encoding option to infer-schema command and allow users to change encoding.