### PR TITLE
Fix/retry rate limit exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,29 @@
 
 # Release notes
 
-# 1.4.1:
+# 1.5.0:
+__Improvement__:
+- add `SL_PRUNE_PARTITION_ON_MERGE` settings to prune partition on merge. Currently for bigquery only. Recommended to be set to true for load scenarios with merge.
+- add `partitionPruningKey` and `quotedPartitionPruningKey` variables in write strategy templates. They are only set when target table's partition column is one of the merge keys and feature is enabled. 
+
 __Bug fix__:
 - fix index out of bound exception when extracting table name from file name
+- add rate limit exception retry during table deletion
+- fix premature shutdown of parallel executions
+- fix incoming data kept for current partition day only when table is partitionned with bq native and requires temporary tables. Now, it follows target expiration. Affected jobs met the criteria below and is recommended to upgrade to this version:
+  - target table is partitionned
+  - incoming data partitions are older than yesterday 
+  - and one of:
+    - any load job with scripted fields or ignored fields
+    - use merge strategy: scd2, upsert_by_key, delete_then_insert, upsert_by_key_and_timestamp
+    - filter incoming data
+    - archiveTable
+    - detailedLoadAudit is enabled with multiple files to ingest at once (SL_GROUPED set to true)
 
 # 1.4.0
 
 __New Feature__:
 - add the ability to have ingestion audit per input file by setting SL_DETAILED_LOAD_AUDIT to true. Useful when there is too many files that generates log entry or sql query higher than the limit.
-- add rate limit exception retry during table deletion
-- fix premature shutdown of parallel executions
 
 __Improvement__:
 - add rawDomains variable in dag templates in order to have access to the whole domain configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ __Bug fix__:
 
 __New Feature__:
 - add the ability to have ingestion audit per input file by setting SL_DETAILED_LOAD_AUDIT to true. Useful when there is too many files that generates log entry or sql query higher than the limit.
+- add rate limit exception retry during table deletion
+- fix premature shutdown of parallel executions
 
 __Improvement__:
 - add rawDomains variable in dag templates in order to have access to the whole domain configuration

--- a/src/main/resources/reference-general.conf
+++ b/src/main/resources/reference-general.conf
@@ -75,6 +75,10 @@ tests = ${?SL_TESTS}
 testCsvNullString = "null"
 testCsvNullString = ${?SL_TEST_CSV_NULL_STRING}
 
+# prunePartitionOnMerge / SL_PRUNE_PARTITION_ON_MERGE: pre-compute incoming partitions to prune partitions on merge statement
+prunePartitionOnMerge = false
+prunePartitionOnMerge = ${?SL_PRUNE_PARTITION_ON_MERGE}
+
 # write strategies path, may be relative or absolute
 writeStrategies = ${metadata}"/write-strategies"
 writeStrategies = ${?SL_WRITE_STRATEGIES}

--- a/src/main/resources/starlake.json
+++ b/src/main/resources/starlake.json
@@ -2052,6 +2052,10 @@
           "$ref": "#/definitions/ConvertibleToString",
           "description": "Path to tests folder. Default is ${metadata}/tests"
         },
+        "prunePartitionOnMerge": {
+          "type": "boolean",
+          "description": "Pre-compute incoming partitions to prune partitions on merge statement"
+        },
         "writeStrategies": {
           "$ref": "#/definitions/ConvertibleToString",
           "description": "Location where are located user defined write strategies; Default is ${metadata}/write-strategies"

--- a/src/main/resources/templates/write-strategies/bigquery/delete_then_insert.j2
+++ b/src/main/resources/templates/write-strategies/bigquery/delete_then_insert.j2
@@ -1,3 +1,6 @@
+{% if quotedPartitionPruningKey != '' %}
+DECLARE incomingPartitionKeys DEFAULT (select array_agg(distinct {{ quotedPartitionPruningKey }}) from ({{ selectStatement }}));
+{% endif %}
 MERGE INTO {{ tableFullName  }} SL_EXISTING
 USING (
   WITH
@@ -6,7 +9,7 @@ USING (
     FROM ({{ selectStatement }})
   ),
   sl_existing_keys AS (
-    select distinct {{ strategyKeyCsv }} from {{ tableFullName  }}
+    select distinct {{ strategyKeyCsv }} from {{ tableFullName  }}{% if quotedPartitionPruningKey != '' %} where {{ quotedPartitionPruningKey }} IN unnest(incomingPartitionKeys){% endif %}
   ),
   line_action as(
     select
@@ -21,6 +24,6 @@ USING (
   )
   select * from line_action
 ) SL_INCOMING
-ON {% for mergeKey in quotedStrategyKey %}SL_EXISTING.{{ mergeKey }} = SL_INCOMING.{{ mergeKey }} AND {%endfor%}SL_INCOMING.sl_merge_action = 'KEEP'
-WHEN NOT MATCHED BY SOURCE THEN DELETE
+ON {% if quotedPartitionPruningKey != '' %}FALSE{% else %}{% for mergeKey in quotedStrategyKey %}SL_EXISTING.{{ mergeKey }} = SL_INCOMING.{{ mergeKey }} AND {%endfor%}SL_INCOMING.sl_merge_action = 'KEEP'{% endif %}
+WHEN NOT MATCHED BY SOURCE{% if quotedPartitionPruningKey != '' %} AND SL_EXISTING.{{ quotedPartitionPruningKey }} IN unnest(incomingPartitionKeys){% endif %} THEN DELETE
 WHEN NOT MATCHED THEN {{ tableInsert }}

--- a/src/main/resources/templates/write-strategies/bigquery/upsert_by_key.j2
+++ b/src/main/resources/templates/write-strategies/bigquery/upsert_by_key.j2
@@ -1,6 +1,12 @@
+{% if quotedPartitionPruningKey != '' %}
+DECLARE incomingPartitionKeys DEFAULT (select array_agg(distinct {{ quotedPartitionPruningKey }}) from ({{ selectStatement }}));
+{% endif %}
 {% if strategyOn == 'TARGET' %}
 
-MERGE INTO  {{ tableFullName }} SL_EXISTING USING ({{ selectStatement }}) SL_INCOMING ON ( {{ strategyKeyJoinCondition }})
+MERGE INTO  {{ tableFullName }} SL_EXISTING USING (
+    {{ selectStatement }}
+) SL_INCOMING
+ON ({{ strategyKeyJoinCondition }}{% if quotedPartitionPruningKey != '' %} AND SL_EXISTING.{{ quotedPartitionPruningKey }} IN unnest(incomingPartitionKeys) {% endif %})
 WHEN MATCHED THEN  UPDATE {{ tableUpdateSetExpression }}
 WHEN NOT MATCHED THEN {{ tableInsert }}
 
@@ -12,7 +18,7 @@ USING (
   FROM ({{ selectStatement }})
   QUALIFY ROW_NUMBER() OVER (PARTITION BY {{ strategyKeyCsv }}  ORDER BY (select 0)) = 1
 ) SL_INCOMING
-ON ( {{strategyKeyJoinCondition}} )
+ON ({{ strategyKeyJoinCondition }}{% if quotedPartitionPruningKey != '' %} AND SL_EXISTING.{{ quotedPartitionPruningKey }} IN unnest(incomingPartitionKeys) {% endif %})
 WHEN MATCHED THEN UPDATE {{ tableUpdateSetExpression }}
 WHEN NOT MATCHED THEN {{ tableInsert }}
 

--- a/src/main/resources/templates/write-strategies/bigquery/upsert_by_key_and_timestamp.j2
+++ b/src/main/resources/templates/write-strategies/bigquery/upsert_by_key_and_timestamp.j2
@@ -1,6 +1,12 @@
+{% if quotedPartitionPruningKey != '' %}
+DECLARE incomingPartitionKeys DEFAULT (select array_agg(distinct {{ quotedPartitionPruningKey }}) from ({{ selectStatement }}));
+{% endif %}
 {% if strategyOn == 'TARGET' %}
 
-MERGE INTO  {{ tableFullName }} SL_EXISTING USING ({{ selectStatement }}) SL_INCOMING ON ( {{ strategyKeyJoinCondition }})
+MERGE INTO  {{ tableFullName }} SL_EXISTING USING (
+    {{ selectStatement }}
+) SL_INCOMING
+ON ( {{ strategyKeyJoinCondition }}{% if quotedPartitionPruningKey != '' %} AND SL_EXISTING.{{ quotedPartitionPruningKey }} IN unnest(incomingPartitionKeys) {% endif %})
 WHEN MATCHED AND SL_INCOMING.{{ strategyTimestamp }} > SL_EXISTING.{{ strategyTimestamp }} THEN  UPDATE {{ tableUpdateSetExpression }}
 WHEN NOT MATCHED THEN {{ tableInsert }}
 
@@ -12,7 +18,7 @@ USING (
     FROM ({{ selectStatement }})
     QUALIFY ROW_NUMBER() OVER (PARTITION BY {{ strategyKeyCsv }}  ORDER BY {{ strategyTimestamp }} DESC) = 1    
 ) SL_INCOMING
-ON ( {{ strategyKeyJoinCondition }})
+ON ( {{ strategyKeyJoinCondition }}{% if quotedPartitionPruningKey != '' %} AND SL_EXISTING.{{ quotedPartitionPruningKey }} IN unnest(incomingPartitionKeys) {% endif %})
 WHEN MATCHED AND SL_INCOMING.{{ strategyTimestamp }} > SL_EXISTING.{{ strategyTimestamp }} THEN  UPDATE {{ tableUpdateSetExpression }}
 WHEN NOT MATCHED THEN {{ tableInsert }}
 

--- a/src/main/scala/ai/starlake/config/Settings.scala
+++ b/src/main/scala/ai/starlake/config/Settings.scala
@@ -577,7 +577,11 @@ object Settings extends StrictLogging {
     columnRemarks: Option[String] = None,
     tableRemarks: Option[String] = None,
     supportsJson: Option[Boolean] = None
-  )
+  ) {
+    def quoteIdentifier(anyIdentifier: String) = {
+      s"$quote$anyIdentifier$quote"
+    }
+  }
 
   object JdbcEngine {
 
@@ -714,6 +718,7 @@ object Settings extends StrictLogging {
     dags: String,
     tests: String,
     writeStrategies: String,
+    prunePartitionOnMerge: Boolean,
     loadStrategies: String,
     metadata: String,
     metrics: Metrics,

--- a/src/main/scala/ai/starlake/job/ingest/loaders/BigQueryNativeLoader.scala
+++ b/src/main/scala/ai/starlake/job/ingest/loaders/BigQueryNativeLoader.scala
@@ -60,7 +60,6 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
           accessToken = accessToken
         )
       if (twoSteps) {
-        val startTime = System.currentTimeMillis()
         val (loadResults, tempTableIds, tableInfos) =
           ParUtils
             .runInParallel(settings.appConfig.maxParTask, path.map(_.toString).zipWithIndex) {
@@ -136,8 +135,6 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
           }
         }
 
-        println("First step done in : " + ExtractUtils.toHumanElapsedTimeFrom(startTime))
-
         val output: Try[List[BqLoadInfo]] =
           applyBigQuerySecondStep(
             targetConfig,
@@ -158,7 +155,9 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
           archiveTableTask(database, schema, table, info).foreach(_.run())
         }
         Try(ParUtils.runInParallel(settings.appConfig.maxParTask, tempTableIds) { tableId =>
-          new BigQueryNativeJob(targetConfig, "").dropTable(tableId)
+          BigQueryJobBase.recoverBigqueryException {
+            new BigQueryNativeJob(targetConfig, "").dropTable(tableId)
+          }
         })
           .flatMap(_ => output)
           .recoverWith { case exception =>

--- a/src/main/scala/ai/starlake/job/ingest/loaders/BigQueryNativeLoader.scala
+++ b/src/main/scala/ai/starlake/job/ingest/loaders/BigQueryNativeLoader.scala
@@ -76,7 +76,6 @@ class BigQueryNativeLoader(ingestionJob: IngestionJob, accessToken: Option[Strin
                       source = Left(sourceUri),
                       outputTableId = Some(firstStepTempTable),
                       outputTableDesc = Some("Temporary table created during data ingestion."),
-                      days = Some(1),
                       // force first step to be write append, otherwise write_truncate overwrite the
                       // created structure with default values, making second step query to fail if it relies on
                       // technical column such as comet_input_filename.

--- a/src/test/scala/ai/starlake/schema/generator/YamlSerdeSpec.scala
+++ b/src/test/scala/ai/starlake/schema/generator/YamlSerdeSpec.scala
@@ -1301,6 +1301,7 @@ object YamlConfigGenerators {
       datasets                   <- arbitrary[String]
       tests                      <- arbitrary[String]
       dags                       <- arbitrary[String]
+      prunePartitionOnMerge      <- arbitrary[Boolean]
       writeStrategies            <- arbitrary[String]
       loadStrategies             <- arbitrary[String]
       metadata                   <- arbitrary[String]
@@ -1381,6 +1382,7 @@ object YamlConfigGenerators {
       datasets = datasets,
       tests = tests,
       dags = dags,
+      prunePartitionOnMerge = prunePartitionOnMerge,
       writeStrategies = writeStrategies,
       loadStrategies = loadStrategies,
       metadata = metadata,


### PR DESCRIPTION

# FEAT: Bigquery merge optimization on partitionned table
Given a table partitionned with date and having data for every hours (in our case, hourly observed weather), the target table contains 161,57 GB.

When SL_PRUNE_PARTITION_ON_MERGE is set to False,

Ingestion of one hourly observed day costs 161,57 GB in bigquery because it scans the whole table.

When it is set to True, then ingestion is done in two steps:
- detecting incoming dates: costs 20 MB
- apply merge for those dates with a replayed date: 
    - incoming data: 765,98 MB
    - target data: 498 MB
    - total merge job cost: 1,22 GB

If target data, doesn't exists, then it would costs only incoming data.

Merge can be optimized because:
- bigquery optimize projected column
- bigquery support partition pruning
- we know incoming partitions data
- partition column is used in merge keys

Therefore, if partition column is in merge keys, only data in that partition are concerned for the merge process. We just have to pre-compute partition column in order to make the filter determinist and have the ability prune partitions.

SCD2 hasn't been optimized in this PR but may be optimized by replacing {{ tableFullName }} with a CTE where tableFullName is filtered on partition to prune existing data. However, it requires testing of different use cases to be sure about the behavior.

# FIX: Add rate limit exception retry during table deletion

Bug fix, parallel table deletion may encounters quota limit. In order to maximize temporary table deletion, retry is applied. If table is not deleted, then temporary tables will expire on their own.

# FIX: premature shutdown of parallel executions
When an error occured, the thread pool were shutdown, preventing other tasks to continue and therefore having a message stating that tasks are submitted after pool is shutdown. Therefore, the new implementation waits for all tasks to be processed before checking the whole results and shutdown the pool.