### PR TITLE
fix: use merged schema with input data to check for two steps requirements instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 
 __Improvement__:
 - look at bigquery job's exceptions recursively to check for a retry
-- **BREAKING CHANGE** New column has been added to the AUDIT table to handle state aware orchestration inside Snowflake Tasks 
+- **BREAKING CHANGE** New column has been added to the AUDIT table to handle state aware orchestration inside Snowflake Tasks
 
 __Bug fix__:
 - schema and data extraction runs in parallel again
+- bigquery native load didn't merge file's DSV schema with starlake schema before checking for two steps load
 
 # 1.5.0:
 __Improvement__:

--- a/src/main/scala/ai/starlake/job/ingest/loaders/NativeLoader.scala
+++ b/src/main/scala/ai/starlake/job/ingest/loaders/NativeLoader.scala
@@ -64,7 +64,7 @@ class NativeLoader(ingestionJob: IngestionJob, accessToken: Option[String])(impl
     settings.appConfig.archiveTable || settings.appConfig.audit.detailedLoadAudit && path.size > 1
   }
 
-  val twoSteps: Boolean = requireTwoSteps(starlakeSchema)
+  lazy val twoSteps: Boolean = requireTwoSteps(effectiveSchema)
 
   lazy val (createDisposition: String, writeDisposition: String) = Utils.getDBDisposition(
     strategy.toWriteMode()


### PR DESCRIPTION
When schema is detected from data for dsv file, it may add additional columns that are set as ignored. Therefore, we then go into a two step ingestion in order to be able to add those additional columns before ignoring them. If not, then we may have a shift on column ingestion and have an error because of the column type or worse, data into the wrong column.
