### PR TITLE
docs: fix broken link to contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-https://comet-app.readthedocs.io/en/latest/developer/contribute.html
+https://docs.starlake.ai/devguide/contribute


### PR DESCRIPTION
## Updated the "How to contribute" link in the documentation. The previous link pointed to a deprecated/broken page.

**Related Issue:** N/A

**PR Type:** Documentation

**Status:** Ready to review

**Breaking change?** No

## Description
### Solution
The documentation contained a link to `https://comet-app.readthedocs.io/...` which is no longer active.
I have updated this link to point to the current official contribution guide: `https://docs.starlake.ai/devguide/contribute`.

### How has this been tested?
- [x] Manually verified that the new link works and redirects to the correct page.

### Other changes
None.

### Deploy Notes
None.

### Remaining Todos
None.

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] I have updated the Release notes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.