### PR TITLE
feat(preload): opt-in "not ready" sentinel via --notReadySentinel

### DIFF
--- a/src/main/scala/ai/starlake/job/ingest/PreLoadCmd.scala
+++ b/src/main/scala/ai/starlake/job/ingest/PreLoadCmd.scala
@@ -54,6 +54,17 @@ trait PreLoadCmd extends Cmd[PreLoadConfig] with LazyLogging {
         .action((x, c) => c.copy(globalAckFilePath = Some(x)))
         .text("Global ack file path"),
       builder
+        .opt[String]("notReadySentinel")
+        .optional()
+        .action((x, c) => c.copy(notReadySentinel = Some(x)))
+        .text(
+          "If set, a zero-byte marker is written at this path when the pre-load decides files are not yet ready. " +
+          "Used by orchestrators to distinguish 'not ready, retry later' from real failures. " +
+          "In this mode, 'not ready' outcomes always exit with code 0 (the sentinel is the signal), " +
+          "while real exceptions still exit non-zero. " +
+          "Supports any StorageHandler-compatible URI (gs://, s3://, file://, hdfs://)."
+        ),
+      builder
         .opt[Map[String, String]]("options")
         .valueName("k1=v1,k2=v2...")
         .optional()
@@ -66,27 +77,48 @@ trait PreLoadCmd extends Cmd[PreLoadConfig] with LazyLogging {
   def parse(args: Seq[String]): Option[PreLoadConfig] =
     OParser.parse(parser, args, PreLoadConfig(domain = ""))
 
+  private def writeSentinelIfRequested(
+    config: PreLoadConfig
+  )(implicit settings: Settings): Unit = {
+    config.notReadySentinel.foreach { sentinelPath =>
+      val path = new Path(sentinelPath)
+      settings.storageHandler().touchz(path) match {
+        case scala.util.Success(_) =>
+          logger.info(s"Wrote not-ready sentinel to $sentinelPath")
+        case scala.util.Failure(e) =>
+          // Best-effort: never mask the real pre-load outcome if sentinel write fails.
+          logger.warn(s"Failed to write not-ready sentinel to $sentinelPath: ${e.getMessage}")
+      }
+    }
+  }
+
   override def run(config: PreLoadConfig, schemaHandler: SchemaHandler)(implicit
     settings: Settings
   ): Try[JobResult] = {
     logger.info(
       s"Pre loading domain ${config.domain} with strategy ${config.strategy.map(_.value).getOrElse("none")}"
     )
+    val sentinelMode = config.notReadySentinel.isDefined
 
     config.strategy match {
       case Some(PreLoadStrategy.Imported) =>
-        schemaHandler.domains(List(config.domain), config.tables.toList).headOption match {
-          case Some(domain) =>
-            Success(
+        val result =
+          schemaHandler.domains(List(config.domain), config.tables.toList).headOption match {
+            case Some(domain) =>
               PreLoadJobResult(
                 config.domain,
                 workflow(schemaHandler)
                   .listStageFiles(domain, dryMode = true)
                   .map(kv => kv._1 -> kv._2.size)
               )
-            )
-          case None =>
-            Success(PreLoadJobResult(config.domain, config.tables.map(t => t -> 0).toMap))
+            case None =>
+              PreLoadJobResult(config.domain, config.tables.map(t => t -> 0).toMap)
+          }
+        if (result.empty && sentinelMode) {
+          writeSentinelIfRequested(config)
+          Success(EmptyJobResult)
+        } else {
+          Success(result)
         }
 
       case Some(PreLoadStrategy.Pending) =>
@@ -101,8 +133,13 @@ trait PreLoadCmd extends Cmd[PreLoadConfig] with LazyLogging {
                 table -> 0
             }
           }
-
-        Success(PreLoadJobResult(config.domain, results.toMap))
+        val result = PreLoadJobResult(config.domain, results.toMap)
+        if (result.empty && sentinelMode) {
+          writeSentinelIfRequested(config)
+          Success(EmptyJobResult)
+        } else {
+          Success(result)
+        }
 
       case Some(PreLoadStrategy.Ack) =>
         config.globalAckFilePath match {
@@ -112,11 +149,19 @@ trait PreLoadCmd extends Cmd[PreLoadConfig] with LazyLogging {
             if (storageHandler.exists(path)) {
               storageHandler.delete(path)
               Success(EmptyJobResult)
+            } else if (sentinelMode) {
+              writeSentinelIfRequested(config)
+              Success(EmptyJobResult)
             } else {
               Success(FailedJobResult)
             }
           case None =>
-            Success(FailedJobResult)
+            if (sentinelMode) {
+              writeSentinelIfRequested(config)
+              Success(EmptyJobResult)
+            } else {
+              Success(FailedJobResult)
+            }
         }
 
       case _ =>

--- a/src/main/scala/ai/starlake/job/ingest/PreLoadConfig.scala
+++ b/src/main/scala/ai/starlake/job/ingest/PreLoadConfig.scala
@@ -8,5 +8,6 @@ case class PreLoadConfig(
   strategy: Option[PreLoadStrategy] = None,
   globalAckFilePath: Option[String] = None,
   options: Map[String, String] = Map.empty,
-  reportFormat: Option[String] = None
+  reportFormat: Option[String] = None,
+  notReadySentinel: Option[String] = None
 ) extends ReportFormatConfig

--- a/src/test/scala/ai/starlake/job/ingest/PreLoadCmdSentinelSpec.scala
+++ b/src/test/scala/ai/starlake/job/ingest/PreLoadCmdSentinelSpec.scala
@@ -1,0 +1,181 @@
+package ai.starlake.job.ingest
+
+import ai.starlake.TestHelper
+import ai.starlake.utils.{EmptyJobResult, FailedJobResult, PreLoadJobResult}
+import org.apache.hadoop.fs.Path
+
+import java.nio.file.Files
+
+class PreLoadCmdSentinelSpec extends TestHelper {
+  new WithSettings() {
+
+    private def freshTempDir(): String =
+      Files.createTempDirectory("preload-sentinel-test-").toString
+
+    // --- Parser --------------------------------------------------------------
+
+    "PreLoad parser" should "accept the --notReadySentinel option" in {
+      val parsed = PreLoadCmd.parse(
+        Seq(
+          "--domain",
+          "sales",
+          "--tables",
+          "customers",
+          "--strategy",
+          "imported",
+          "--notReadySentinel",
+          "file:///tmp/preload-sentinel-parser.flag"
+        )
+      )
+      parsed.flatMap(_.notReadySentinel) shouldBe Some(
+        "file:///tmp/preload-sentinel-parser.flag"
+      )
+    }
+
+    "PreLoad parser" should "leave notReadySentinel as None when the flag is absent" in {
+      val parsed = PreLoadCmd.parse(
+        Seq(
+          "--domain",
+          "sales",
+          "--strategy",
+          "imported"
+        )
+      )
+      parsed.flatMap(_.notReadySentinel) shouldBe None
+    }
+
+    // --- ACK strategy: legacy mode (no sentinel flag) ------------------------
+
+    "ACK strategy, file missing, no sentinel flag" should "return FailedJobResult (legacy behavior)" in {
+      val dir = freshTempDir()
+      val ackPath = s"file://$dir/missing.ack"
+
+      val config = PreLoadConfig(
+        domain = "any",
+        strategy = Some(PreLoadStrategy.Ack),
+        globalAckFilePath = Some(ackPath),
+        notReadySentinel = None
+      )
+      val result = PreLoadCmd.run(config, settings.schemaHandler())
+
+      result.get shouldBe FailedJobResult
+    }
+
+    // --- ACK strategy: sentinel mode -----------------------------------------
+
+    "ACK strategy, file missing, sentinel mode" should "write the sentinel and return EmptyJobResult (not FailedJobResult)" in {
+      val dir = freshTempDir()
+      val sentinelPath = s"file://$dir/notready.flag"
+      val ackPath = s"file://$dir/missing.ack"
+
+      val config = PreLoadConfig(
+        domain = "any",
+        strategy = Some(PreLoadStrategy.Ack),
+        globalAckFilePath = Some(ackPath),
+        notReadySentinel = Some(sentinelPath)
+      )
+      val result = PreLoadCmd.run(config, settings.schemaHandler())
+
+      result.get shouldBe EmptyJobResult
+      settings.storageHandler().exists(new Path(sentinelPath)) shouldBe true
+    }
+
+    "ACK strategy, file present, sentinel mode" should "return EmptyJobResult and NOT write the sentinel" in {
+      val dir = freshTempDir()
+      val sentinelPath = s"file://$dir/notready.flag"
+      val ackPath = s"file://$dir/present.ack"
+      settings.storageHandler().touchz(new Path(ackPath)).get
+
+      val config = PreLoadConfig(
+        domain = "any",
+        strategy = Some(PreLoadStrategy.Ack),
+        globalAckFilePath = Some(ackPath),
+        notReadySentinel = Some(sentinelPath)
+      )
+      val result = PreLoadCmd.run(config, settings.schemaHandler())
+
+      result.get shouldBe EmptyJobResult
+      settings.storageHandler().exists(new Path(sentinelPath)) shouldBe false
+    }
+
+    "ACK strategy, no globalAckFilePath, sentinel mode" should "write the sentinel and return EmptyJobResult" in {
+      val dir = freshTempDir()
+      val sentinelPath = s"file://$dir/notready.flag"
+
+      val config = PreLoadConfig(
+        domain = "any",
+        strategy = Some(PreLoadStrategy.Ack),
+        globalAckFilePath = None,
+        notReadySentinel = Some(sentinelPath)
+      )
+      val result = PreLoadCmd.run(config, settings.schemaHandler())
+
+      result.get shouldBe EmptyJobResult
+      settings.storageHandler().exists(new Path(sentinelPath)) shouldBe true
+    }
+
+    // --- IMPORTED strategy ---------------------------------------------------
+    // With no domains registered, schemaHandler.domains(...) returns empty,
+    // exercising the `case None` fallback branch at PreLoadCmd.scala:88-90,
+    // which produces a PreLoadJobResult with all-zero counts (empty == true).
+
+    "IMPORTED strategy, empty result, no sentinel flag" should "return an empty PreLoadJobResult (legacy behavior) and write no sentinel" in {
+      val dir = freshTempDir()
+
+      val config = PreLoadConfig(
+        domain = "nosuch",
+        tables = Seq("customers"),
+        strategy = Some(PreLoadStrategy.Imported),
+        notReadySentinel = None
+      )
+      val result = PreLoadCmd.run(config, settings.schemaHandler()).get
+
+      result shouldBe a[PreLoadJobResult]
+      result.asInstanceOf[PreLoadJobResult].empty shouldBe true
+
+      Files
+        .list(new java.io.File(dir).toPath)
+        .count() shouldBe 0L
+    }
+
+    "IMPORTED strategy, empty result, sentinel mode" should "write the sentinel and return EmptyJobResult (not an empty PreLoadJobResult)" in {
+      val dir = freshTempDir()
+      val sentinelPath = s"file://$dir/notready.flag"
+
+      val config = PreLoadConfig(
+        domain = "nosuch",
+        tables = Seq("customers"),
+        strategy = Some(PreLoadStrategy.Imported),
+        notReadySentinel = Some(sentinelPath)
+      )
+      val result = PreLoadCmd.run(config, settings.schemaHandler())
+
+      result.get shouldBe EmptyJobResult
+      settings.storageHandler().exists(new Path(sentinelPath)) shouldBe true
+    }
+
+    // --- Robustness ----------------------------------------------------------
+
+    "sentinel write failure" should "be non-fatal and preserve the sentinel-mode result (EmptyJobResult)" in {
+      val dir = freshTempDir()
+      // Point the sentinel at a path that cannot be written: a path whose
+      // parent is a regular file (not a directory), causing touchz to fail.
+      val blockingFile = s"$dir/blocker"
+      Files.createFile(new java.io.File(blockingFile).toPath)
+      val unwritableSentinelPath = s"file://$blockingFile/notready.flag"
+      val ackPath = s"file://$dir/missing.ack"
+
+      val config = PreLoadConfig(
+        domain = "any",
+        strategy = Some(PreLoadStrategy.Ack),
+        globalAckFilePath = Some(ackPath),
+        notReadySentinel = Some(unwritableSentinelPath)
+      )
+      val result = PreLoadCmd.run(config, settings.schemaHandler())
+
+      // Contract: the caller's view of sentinel-mode outcomes is preserved
+      // even if the side-channel write fails. Only a warning is logged.
+      result.get shouldBe EmptyJobResult
+    }
+  }
+}


### PR DESCRIPTION
Adds a CLI flag that lets the orchestration layer (Airflow / Dagster) distinguish "files not ready yet, retry later" from "real failure" when the pre-load step runs in Cloud Run or any other remote executor that only surfaces a single non-zero exit code.

Contract:
- --notReadySentinel not passed → legacy behavior preserved. Not-ready outcomes (IMPORTED/PENDING find zero files, ACK file missing) still produce FailedJobResult / empty PreLoadJobResult → exit 1.
- --notReadySentinel <uri> passed → not-ready outcomes write a zero-byte marker at <uri> via StorageHandler.touchz (cloud-agnostic: gs://, s3://, file://, hdfs://) AND return EmptyJobResult so Main.scala maps them to exit 0. Genuine exceptions still exit non-zero and never reach the sentinel-write site.

Orchestrators using this feature:
- Invoke starlake preload with --notReadySentinel <derived-path>.
- After the Cloud Run job succeeds (exit 0), check the sentinel URI. If present, the pre-load decided files aren't ready → delete and raise a retry-triggering exception. If absent, files are ready → proceed.
- This keeps the Cloud Run console free of red "Failed" executions for routine "not ready" polls, and makes any non-zero exit an unambiguous "real crash" signal.

Changes:
- PreLoadConfig: new optional field notReadySentinel: Option[String].
- PreLoadCmd: new scopt option; new writeSentinelIfRequested helper (best-effort — log-and-continue on write failure, never masks the pre-load outcome); three "not ready" code paths updated (Imported, Pending, Ack — both FailedJobResult branches).
- PreLoadCmdSentinelSpec (new, 9 tests): legacy mode preserved, sentinel mode correctness for all three strategies, sentinel write-failure is non-fatal, parser accepts/omits the flag.

Orchestration-side consumer lands separately in the starlake-orchestration repo.

## Summary
A clear and concise description of the overall goals of the pull request's commits.

**Related Issue: #IssueId**

**PR Type: Bug Fix | Feature | Documentation**

**Status: WIP/Ready to review**

**Breaking change? Yes/No**


## Description
### Solution
Describe your changes in detail

### How has this been tested?
Outline the steps taken to test the PR (unit tests? Integration tests? tested impacts on other project features? ...)

### Other changes
Describe any other additional work done:
bug fixes, tweaks, small refactors

### Deploy Notes
Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, new environment variables, ...

### Remaining Todos
This should be done before merging this PR:
* [ ] - Task1
* [ ] - Task2

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] I have updated the Release notes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



